### PR TITLE
fix hard-coded session cookie name

### DIFF
--- a/swimlane/core/auth/user_pass_auth_provider.py
+++ b/swimlane/core/auth/user_pass_auth_provider.py
@@ -1,5 +1,4 @@
-"""
-This module provides a username/password-based authentication provider to be
+"""This module provides a username/password-based authentication provider to be
 used by Client.
 """
 
@@ -8,9 +7,6 @@ try:
     from urllib.parse import urljoin
 except ImportError:
     from urlparse import urljoin
-
-
-COOKIE_NAME = ".AspNetCore.Identity.Application"
 
 
 class UserPassAuthProvider(object):
@@ -39,7 +35,7 @@ class UserPassAuthProvider(object):
         """Get an auth header that can be used for HTTP requests.
 
         Returns:
-            dict: A dict that can be converted to an HTTP request header.
+            dict: A dict that contains session cookies used in every futher HTTP request.
         """
         creds = {"username": self.username, "password": self.password}
         resp = requests.post(self.base_url, json=creds, verify=self.verify_ssl)
@@ -47,4 +43,6 @@ class UserPassAuthProvider(object):
         # Raise any underlying HTTPErrors if they occured
         resp.raise_for_status()
 
-        return {"Cookie": COOKIE_NAME + "=" + resp.cookies[COOKIE_NAME]}
+        return {'Cookie': ';'.join(
+            ["%s=%s" % cookie for cookie in resp.cookies.items()]
+        )}

--- a/tests/core/auth/test_user_pass_auth_provider.py
+++ b/tests/core/auth/test_user_pass_auth_provider.py
@@ -26,3 +26,25 @@ class UserPassAuthProviderTestCase(unittest.TestCase):
             json={'username': 'user', 'password': 'pass'},
             verify=True)
         mock_requests.post.return_value.raise_for_status.assert_called_once_with()  # noqa
+
+    @patch('swimlane.core.auth.user_pass_auth_provider.requests', autospec=True)
+    def test_multiple_cookies(self, mock_requests):
+        mock_requests.post.return_value.cookies = {
+            'cookie_1': 'value_1',
+            'cookie_2': 'value_2',
+        }
+
+        u = UserPassAuthProvider('server', 'user', 'pass')
+        header = u.auth_header()
+
+        self.assertIn('Cookie', header) 
+        self.assertIn('cookie_1=value_1', header['Cookie'])
+        self.assertIn('cookie_2=value_2', header['Cookie'])
+        # test that cookies are separated with semicolon
+        self.assertIn(';', header['Cookie'])
+
+        mock_requests.post.assert_called_once_with(
+            'user/login',
+            json={'username': 'user', 'password': 'pass'},
+            verify=True)
+        mock_requests.post.return_value.raise_for_status.assert_called_once_with()  # noqa


### PR DESCRIPTION
I've found that latest release of swimlane-python client version **0.1.0** expects to find session cookie in [**.AspNetCore.Identity.Application**](https://github.com/swimlane/swimlane-python/blob/69b9a648b1f27657ba44e9e14b8eacf2bad8a3a9/swimlane/core/auth/user_pass_auth_provider.py#L13)

But Swimlane API server version **2.10.27** contains session cookie value in **.AspNet.ApplicationCookie** in HTTP response:

> Server: Microsoft-IIS/8.5
> X-AspNet-Version: 4.0.3031
> Set-Cookie: **.AspNet.AppcationCookie**=some_value; path=/; secure; HttpOnly
> X-Powered-By: ASP.NET

So it makes impossible to use latest swimlane python client **0.1.0** with Swimlane API server version **2.10.27**.