### PR TITLE
PYD-87 Add automatic reauthentication when JWT is about to expire

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cachetools>=2.0,<2.1
 certifi>=2017
 pendulum>=1.2.3,<1.3
+pyjwt>=1.6,<1.7
 pyuri>=0.3,<0.4
 requests[security]>=2,<3
 six>=1.10,<1.11

--- a/swimlane/core/cache.py
+++ b/swimlane/core/cache.py
@@ -30,7 +30,7 @@ class ResourcesCache(object):
         self.__cache_index_key_map = {}
 
         if self.__cache_max_size == 0:
-            logger.warning('Cache size set to 0, resource caching disabled')
+            logger.debug('Cache size set to 0, resource caching disabled')
 
     def __len__(self):
         """Return sum of all cache sizes"""

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -287,8 +287,7 @@ class SwimlaneAuth(SwimlaneResolver):
             'user/login',
             json={
                 'userName': self._username,
-                'password': self._password,
-                'domain': ''
+                'password': self._password
             },
         )
         self._swimlane._session.auth = self

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,13 @@ from swimlane.core.resources.record import Record
 from swimlane.core.resources.usergroup import User, Group
 from swimlane.core.resources.report import Report
 
+
 @pytest.fixture
 def mock_swimlane():
     """Return a mock Swimlane client"""
+    # Patch around SwimlaneAuth.authenticate sending request, and manually assign a User instance
     with mock.patch('swimlane.core.client.requests.Session', mock.MagicMock()):
-        with mock.patch.object(SwimlaneAuth, 'authenticate', return_value=(None, {})):
+        with mock.patch.object(SwimlaneAuth, 'authenticate'):
             swimlane = Swimlane('http://host', 'admin', 'password', verify_server_version=False)
             swimlane._Swimlane__settings = {
                 'apiVersion': '3.0+5.0.0+123456'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -106,54 +106,11 @@ def test_server_version_checks():
 
 
 def test_auth(mock_swimlane):
-    """Test automatic auth request and header injection with automatic version handling"""
+    """Test automatic auth request and header injection"""
     with mock.patch.object(mock_swimlane._session, 'request') as mock_request:
         mock_response = mock.MagicMock()
         mock_request.return_value = mock_response
 
-        # Swimlane v2.13-
-        mock_response.json.return_value = {
-            '$type': 'API.Models.Identity.AuthorizeModel, API',
-            'active': False,
-            'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core'},
-            'createdDate': '2017-03-31T09:10:52.717Z',
-            'disabled': False,
-            'displayName': 'admin',
-            'groups': [{'$type': 'Core.Models.Base.Entity, Core',
-                        'disabled': False,
-                        'id': '58de1d1c07637a0264c0ca71',
-                        'name': 'Everyone'}],
-            'id': '58de1d1c07637a0264c0ca6a',
-            'isAdmin': True,
-            'isMe': True,
-            'lastLogin': '2017-04-27T14:11:38.54Z',
-            'lastPasswordChangedDate': '2017-03-31T09:10:52.536Z',
-            'modifiedByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core'},
-            'modifiedDate': '2017-03-31T09:10:52.76Z',
-            'name': 'admin',
-            'passwordComplexityScore': 3,
-            'passwordResetRequired': False,
-            'permission': {'$type': 'Core.Models.Security.PermissionMatrix, Core'},
-            'roles': [{'$type': 'Core.Models.Base.Entity, Core',
-                       'disabled': False,
-                       'id': '58de1d1c07637a0264c0ca64',
-                       'name': 'Administrator'}],
-            'userName': 'admin',
-            'users': []}
-
-        mock_response.cookies.items.return_value = [('.AspNetCore.Identity.Application',
-                                                     'CfDJ8Eq07zdLE8ZGtPyzBNIkJhIgJB4-EUThghuYsSpPGU6fiO0uXHSfU2LDOmrpxmfa8KAVjMI1JSL1YyXzCXavaTMT7ZBwUO9J6rJG3m2p3B8hHFMd4RGRQypqP-znY6VEJmrvVr6_ZSF8sx-E54FI2N5WQo7gfiqGVIX70WrqyTvbaU1spoGsTRsXs1BJaUeobhSrI8MWjouqXSDuhcTJjjGczq_LGlBkdzYpV1wzPJSiwWXs-ZN2pIJzfMOedAJRs0OzIvVbB8aUn0zKfUu5K3QHhKImdudDqsEadGtTLccygC6t9b6XqIueMGuOYnn7mmOUv6MJBwdzTCfh2Eg4ElYOB8pqZsedWSbXz1GYuTlTpLWihJTwADMKtucIX1myfM4M9DVng_P9yp6K2BHm9_2jEcGJhnJQ2zJBML8TpRpdwhzz3iKBhBohFPqudEJ535zaR4onSO7dFGwbfx-fyZ5E31BNGl70A--y3VcNHeDqzs13ylpR--4DykUTGRnoYjsDFuD4ZHopvNGA8aC0LszaYeVW0M0aUzKw8VbiJdB3xQr9u6wkwscdzG3DqmJGgA')]
-
-        auth = SwimlaneAuth(mock_swimlane, 'admin', 'password')
-
-        assert auth._login_headers == {
-            'Cookie': '.AspNetCore.Identity.Application=CfDJ8Eq07zdLE8ZGtPyzBNIkJhIgJB4-EUThghuYsSpPGU6fiO0uXHSfU2LDOmrpxmfa8KAVjMI1JSL1YyXzCXavaTMT7ZBwUO9J6rJG3m2p3B8hHFMd4RGRQypqP-znY6VEJmrvVr6_ZSF8sx-E54FI2N5WQo7gfiqGVIX70WrqyTvbaU1spoGsTRsXs1BJaUeobhSrI8MWjouqXSDuhcTJjjGczq_LGlBkdzYpV1wzPJSiwWXs-ZN2pIJzfMOedAJRs0OzIvVbB8aUn0zKfUu5K3QHhKImdudDqsEadGtTLccygC6t9b6XqIueMGuOYnn7mmOUv6MJBwdzTCfh2Eg4ElYOB8pqZsedWSbXz1GYuTlTpLWihJTwADMKtucIX1myfM4M9DVng_P9yp6K2BHm9_2jEcGJhnJQ2zJBML8TpRpdwhzz3iKBhBohFPqudEJ535zaR4onSO7dFGwbfx-fyZ5E31BNGl70A--y3VcNHeDqzs13ylpR--4DykUTGRnoYjsDFuD4ZHopvNGA8aC0LszaYeVW0M0aUzKw8VbiJdB3xQr9u6wkwscdzG3DqmJGgA'}
-
-        mock_inflight_request = mock.MagicMock()
-        auth(mock_inflight_request)
-        mock_inflight_request.headers.update.assert_called_once_with(auth._login_headers)
-
-        # Swimlane v2.14+
         JWT_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOiJhTHFfcWlCWVJyVThoIiwidW5pcXVlX25hbWUiOiJhZG1pbiIsIm5iZiI6MTQ5MzMzMTQyNCwiZXhwIjoxNDkzMzM1MDI0LCJpYXQiOjE0OTMzMzE0MjQsImlzcyI6IlN3aW1sYW5lIiwiYXVkIjoiU3dpbWxhbmUifQ.w27D6JgYj6UuoTUivUmwNv8USqeieTTPwmmhJviiDRQ'
 
         mock_response.json.return_value = {
@@ -192,10 +149,12 @@ def test_auth(mock_swimlane):
 
         auth = SwimlaneAuth(mock_swimlane, 'admin', 'password')
 
-        assert auth._login_headers == {'Authorization': 'Bearer {}'.format(JWT_TOKEN)}
-
         mock_inflight_request = mock.MagicMock()
         auth(mock_inflight_request)
+
+        # Assert login headers assigned after first call when automatic authenticate is called due to being past token
+        # expiration window
+        assert auth._login_headers == {'Authorization': 'Bearer {}'.format(JWT_TOKEN)}
         mock_inflight_request.headers.update.assert_called_once_with(auth._login_headers)
 
 


### PR DESCRIPTION
* Added automatic reauthentication when JWT is within 5 minutes of expiring whenever a request is about to be sent to Swimlane
* Removed sub-v2.13 login support
* Minor fixes and logging tweaks

Tested with debugger, manually highjacking token expiration date to 6 minutes past initial login time, and repeatedly pulling list of all apps. Verified first call within 5 minutes of faked token expiration waits until token is refreshed as expected, script attached to Jira. 

Can work with QA to verify against Swimlane with lower JWT expiration timeout, wasn't sure where that config was, and didn't want to impact anyone using the same server. 
