### PR TITLE
Use existing IDs for any values already in list fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('./README.rst') as f:
 
 
 setup(
-    version="4.0.0",
+    version="4.0.2",
     name="swimlane",
     author="Swimlane LLC",
     author_email="info@swimlane.com",


### PR DESCRIPTION
Rolled back to pre-4.0.1 changes, should take this PR over those changes. Still need to add unit tests to assert fix, but quick tested in debugger and seems to be working. 

* Backwards compatible, iteration still works over values without exposing IDs
* Numeric and Text field
* Reuses existing IDs for any values already in list
* Keeps existing IDs for sort, reverse, etc. operations, and respects any new ordering
* Respects field lifecycle, IDs restored during save, any modifications done between get and each save don't matter