### PR TITLE
PYD-85 - Update Python driver to support token authentication

### DIFF
--- a/docs/examples/client.rst
+++ b/docs/examples/client.rst
@@ -27,6 +27,15 @@ If no scheme is provided, HTTPS is used as the default.
     swimlane = Swimlane('192.168.1.1', 'username', 'password')
 
 
+A personal access token generated can also be used in place of a username and password.
+
+.. code-block:: python
+
+    from swimlane import Swimlane
+
+    swimlane = Swimlane('192.168.1.1', access_token='abcdefg')
+
+
 Clear HTTP Connection
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/examples/client.rst
+++ b/docs/examples/client.rst
@@ -27,7 +27,7 @@ If no scheme is provided, HTTPS is used as the default.
     swimlane = Swimlane('192.168.1.1', 'username', 'password')
 
 
-A personal access token generated can also be used in place of a username and password.
+A personal access token can also be used in place of a username and password.
 
 .. code-block:: python
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('./README.rst') as f:
 
 
 setup(
-    version="4.0.0",
+    version="4.1.0",
     name="swimlane",
     author="Swimlane LLC",
     author_email="info@swimlane.com",

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -267,13 +267,7 @@ class SwimlaneTokenAuth(SwimlaneResolver):
         self.user = None
     
     def __call__(self, request):
-        """Attach necessary headers to all requests
-        
-        We always present the access token as part of a custom header, Swimlane should
-        authenticate each request based off the access token. We just need to retrieve
-        the user's info once and then cache it, the access token can be revoked but it
-        can never expire
-        """
+        """Attach necessary headers to all requests"""
 
         headers = {
             'Private-Token': self._access_token
@@ -297,39 +291,6 @@ class SwimlaneTokenAuth(SwimlaneResolver):
         self.user = User(self._swimlane, _user_raw_from_login_content(json_content))
         
         return request
-
-    def _user_raw_from_login_content(self, login_content):
-        """Returns a User instance with appropriate raw data parsed from login response content"""
-        matching_keys = [
-            'displayName',
-            'lastLogin',
-            'active',
-            'name',
-            'isMe',
-            'lastPasswordChangedDate',
-            'passwordResetRequired',
-            'groups',
-            'roles',
-            'email',
-            'isAdmin',
-            'createdDate',
-            'modifiedDate',
-            'createdByUser',
-            'modifiedByUser',
-            'userName',
-            'id',
-            'disabled'
-        ]
-
-        raw_data = {
-            '$type': User._type,
-        }
-
-        for key in matching_keys:
-            if key in login_content:
-                raw_data[key] = login_content[key]
-
-        return raw_data
 
 class SwimlaneAuth(SwimlaneResolver):
     """Handles authentication for all requests"""

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -42,6 +42,7 @@ class Swimlane(object):
             additional requests, set False to disable check
         resource_cache_size (int): Maximum number of each resource type to keep in memory cache. Set 0 to disable
             caching. Disabled by default
+        access_token (str): Authentication token, used in lieu of a username and password
 
     Attributes:
         host (pyuri.URI): Full RFC-1738 URL pointing to Swimlane host
@@ -56,11 +57,18 @@ class Swimlane(object):
 
         ::
 
-            # Establish connection
+            # Establish connection using username password
             swimlane = Swimlane(
                 'https://192.168.1.1',
                 'username',
                 'password',
+                verify_ssl=False
+            )
+
+            # Or establish connection using personal access token
+            swimlane = Swimlane(
+                'https://192.168.1.1',
+                access_token='abcdefg',
                 verify_ssl=False
             )
 

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -91,7 +91,7 @@ class Swimlane(object):
             access_token=None
     ):
         self.__verify_auth_params(username, password, access_token)
-        
+
         self.host = URI(host)
         self.host.scheme = (self.host.scheme or 'https').lower()
         self.host.path = None
@@ -126,7 +126,8 @@ class Swimlane(object):
         if verify_server_version:
             self.__verify_server_version()
 
-    def __verify_auth_params(self, username, password, access_token):
+    @staticmethod
+    def __verify_auth_params(username, password, access_token):
         """Verify that valid authentication parameters were passed to __init__"""
 
         if all(v is not None for v in [username, password, access_token]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import random
 import mock
 import pytest
 
-from swimlane.core.client import SwimlaneAuth, Swimlane
+from swimlane.core.client import SwimlaneJwtAuth, Swimlane
 from swimlane.core.resources.app import App
 from swimlane.core.resources.record import Record
 from swimlane.core.resources.usergroup import User, Group
@@ -15,7 +15,7 @@ def mock_swimlane():
     """Return a mock Swimlane client"""
     # Patch around SwimlaneAuth.authenticate sending request, and manually assign a User instance
     with mock.patch('swimlane.core.client.requests.Session', mock.MagicMock()):
-        with mock.patch.object(SwimlaneAuth, 'authenticate'):
+        with mock.patch.object(SwimlaneJwtAuth, 'authenticate'):
             swimlane = Swimlane('http://host', 'admin', 'password', verify_server_version=False)
             swimlane._Swimlane__settings = {
                 'apiVersion': '3.0+5.0.0+123456'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ import mock
 import pytest
 from requests import HTTPError
 
-from swimlane.core.client import SwimlaneAuth, Swimlane
+from swimlane.core.client import SwimlaneJwtAuth, Swimlane
 from swimlane.exceptions import SwimlaneHTTP400Error, InvalidSwimlaneProductVersion
 
 
@@ -70,7 +70,7 @@ def test_request_handling(mock_swimlane):
 def test_lazy_settings():
     """Test accessing settings is evaluated lazily and cached after first retrieval"""
     with mock.patch.object(Swimlane, 'request') as mock_request:
-        with mock.patch.object(SwimlaneAuth, 'authenticate', return_value=(None, {})):
+        with mock.patch.object(SwimlaneJwtAuth, 'authenticate', return_value=(None, {})):
             mock_response = mock.MagicMock()
             mock_request.return_value = mock_response
 
@@ -93,7 +93,7 @@ def test_lazy_settings():
 def test_server_version_checks():
     """Test that server version is checked by default, raising InvalidServerVersion exception when failing"""
     with mock.patch('swimlane.core.client.requests.Session', mock.MagicMock()):
-        with mock.patch.object(SwimlaneAuth, 'authenticate', return_value=(None, {})):
+        with mock.patch.object(SwimlaneJwtAuth, 'authenticate', return_value=(None, {})):
             with mock.patch.object(Swimlane, 'settings', new_callable=mock.PropertyMock) as mock_settings:
                 mock_settings.return_value = {'apiVersion': '2.18+4.0.0+123456'}
 
@@ -147,7 +147,7 @@ def test_auth(mock_swimlane):
             'userName': 'admin',
             'users': []}
 
-        auth = SwimlaneAuth(mock_swimlane, 'admin', 'password')
+        auth = SwimlaneJwtAuth(mock_swimlane, 'admin', 'password')
 
         mock_inflight_request = mock.MagicMock()
         auth(mock_inflight_request)
@@ -171,7 +171,7 @@ def test_cache_default_disabled(mock_swimlane, mock_record):
 def test_old_version_breakdown():
     """Test that product version, build version, and build number produce expected values in old single value format"""
     with mock.patch('swimlane.core.client.requests.Session', mock.MagicMock()):
-        with mock.patch.object(SwimlaneAuth, 'authenticate', return_value=(None, {})):
+        with mock.patch.object(SwimlaneJwtAuth, 'authenticate', return_value=(None, {})):
             with mock.patch.object(Swimlane, 'settings', new_callable=mock.PropertyMock) as mock_settings:
                 version = '2.17.0-123456'
                 mock_settings.return_value = {'apiVersion': version}
@@ -186,7 +186,7 @@ def test_old_version_breakdown():
 def test_new_version_breakdown():
     """Test that product version, build version, and build number produce expected values in new multi value format"""
     with mock.patch('swimlane.core.client.requests.Session', mock.MagicMock()):
-        with mock.patch.object(SwimlaneAuth, 'authenticate', return_value=(None, {})):
+        with mock.patch.object(SwimlaneJwtAuth, 'authenticate', return_value=(None, {})):
             with mock.patch.object(Swimlane, 'settings', new_callable=mock.PropertyMock) as mock_settings:
                 version = '2.18+4.0.0+123456'
                 mock_settings.return_value = {'apiVersion': version}
@@ -201,7 +201,7 @@ def test_new_version_breakdown():
 def test_host_url_scheme_coercion():
     """Test host URL scheme defaults to 'https' when not provided and is forced to lowercase"""
     with mock.patch.object(Swimlane, 'request') as mock_request:
-        with mock.patch.object(SwimlaneAuth, 'authenticate', return_value=(None, {})):
+        with mock.patch.object(SwimlaneJwtAuth, 'authenticate', return_value=(None, {})):
             mock_response = mock.MagicMock()
             mock_request.return_value = mock_response
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,43 +12,42 @@ def test_api_credential_handling(mock_swimlane):
     error_message = "Must supply a username/password or access token"
 
     with mock.patch.object(Swimlane, 'request') as mock_request:
-        with mock.patch.object(SwimlaneJwtAuth, 'authenticate', return_value=(None, {})):
-            mock_request.return_value = mock.MagicMock()
-    
-            # Throws when all credentials are missing
-            try:
-                mock_swimlane = Swimlane('http://host', verify_server_version=False)
-            except ValueError as error:
-                message = error.args[0]
-                assert message == error_message
-            else:
-                raise RuntimeError
+        mock_request.return_value = mock.MagicMock()
 
-            # Throws when username specified but password is not
-            try:
-                mock_swimlane = Swimlane('http://host', 'username', verify_server_version=False)
-            except ValueError as error:
-                message = error.args[0]
-                assert message == error_message
-            else:
-                raise RuntimeError
+        # Throws when all credentials are missing
+        try:
+            mock_swimlane = Swimlane('http://host', verify_server_version=False)
+        except ValueError as error:
+            message = error.args[0]
+            assert message == error_message
+        else:
+            raise RuntimeError
 
-            # Thows when password specified but username is not
-            try:
-                mock_swimlane = Swimlane('http://host', password='password', verify_server_version=False)
-            except ValueError as error:
-                message = error.args[0]
-                assert message == error_message
-            else:
-                raise RuntimeError
+        # Throws when username specified but password is not
+        try:
+            mock_swimlane = Swimlane('http://host', 'username', verify_server_version=False)
+        except ValueError as error:
+            message = error.args[0]
+            assert message == error_message
+        else:
+            raise RuntimeError
 
-            # Does not throw when username and password supplied, correct auth is used
-            mock_swimlane = Swimlane('http://host', 'username', 'password', verify_server_version=False)
-            assert isinstance(mock_swimlane._session.auth, SwimlaneJwtAuth)
+        # Thows when password specified but username is not
+        try:
+            mock_swimlane = Swimlane('http://host', password='password', verify_server_version=False)
+        except ValueError as error:
+            message = error.args[0]
+            assert message == error_message
+        else:
+            raise RuntimeError
 
-            # Does not throw when access token supplied, correct auth is used
-            mock_swimlane = Swimlane('http://host', access_token='abcdefg', verify_server_version=False)
-            assert isinstance(mock_swimlane._session.auth, SwimlaneTokenAuth)
+        # Does not throw when username and password supplied, correct auth is used
+        mock_swimlane = Swimlane('http://host', 'username', 'password', verify_server_version=False)
+        assert isinstance(mock_swimlane._session.auth, SwimlaneJwtAuth)
+
+        # Does not throw when access token supplied, correct auth is used
+        mock_swimlane = Swimlane('http://host', access_token='abcdefg', verify_server_version=False)
+        assert isinstance(mock_swimlane._session.auth, SwimlaneTokenAuth)
 
 def test_request_handling(mock_swimlane):
     """Test error message and code for SwimlaneHTTP400Error class"""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,9 +3,52 @@ import mock
 import pytest
 from requests import HTTPError
 
-from swimlane.core.client import SwimlaneJwtAuth, Swimlane
+from swimlane.core.client import SwimlaneJwtAuth, SwimlaneTokenAuth, Swimlane
 from swimlane.exceptions import SwimlaneHTTP400Error, InvalidSwimlaneProductVersion
 
+def test_api_credential_handling(mock_swimlane):
+    """Test that __init__ handles username/password pairs and access tokens correctly """
+
+    error_message = "Must supply a username/password or access token"
+
+    with mock.patch.object(Swimlane, 'request') as mock_request:
+        with mock.patch.object(SwimlaneJwtAuth, 'authenticate', return_value=(None, {})):
+            mock_request.return_value = mock.MagicMock()
+    
+            # Throws when all credentials are missing
+            try:
+                mock_swimlane = Swimlane('http://host', verify_server_version=False)
+            except ValueError as error:
+                message = error.args[0]
+                assert message == error_message
+            else:
+                raise RuntimeError
+
+            # Throws when username specified but password is not
+            try:
+                mock_swimlane = Swimlane('http://host', 'username', verify_server_version=False)
+            except ValueError as error:
+                message = error.args[0]
+                assert message == error_message
+            else:
+                raise RuntimeError
+
+            # Thows when password specified but username is not
+            try:
+                mock_swimlane = Swimlane('http://host', password='password', verify_server_version=False)
+            except ValueError as error:
+                message = error.args[0]
+                assert message == error_message
+            else:
+                raise RuntimeError
+
+            # Does not throw when username and password supplied, correct auth is used
+            mock_swimlane = Swimlane('http://host', 'username', 'password', verify_server_version=False)
+            assert isinstance(mock_swimlane._session.auth, SwimlaneJwtAuth)
+
+            # Does not throw when access token supplied, correct auth is used
+            mock_swimlane = Swimlane('http://host', access_token='abcdefg', verify_server_version=False)
+            assert isinstance(mock_swimlane._session.auth, SwimlaneTokenAuth)
 
 def test_request_handling(mock_swimlane):
     """Test error message and code for SwimlaneHTTP400Error class"""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,6 +41,20 @@ def test_api_credential_handling(mock_swimlane):
         else:
             raise RuntimeError
 
+        # Throws when username, password, and access_token specified
+        try:
+            mock_swimlane = Swimlane(
+                'http://host', 
+                'username', 
+                'password', 
+                access_token='abcdefg', 
+                verify_server_version=False)
+        except ValueError as error:
+            message = error.args[0]
+            assert message == 'Cannot supply a username/password and a access token'
+        else:
+            raise RuntimeError
+
         # Does not throw when username and password supplied, correct auth is used
         mock_swimlane = Swimlane('http://host', 'username', 'password', verify_server_version=False)
         assert isinstance(mock_swimlane._session.auth, SwimlaneJwtAuth)


### PR DESCRIPTION
Adds support for authenticating with Swimlane using a personal access token in place of a username and password.

## Overall Design

Updates `SwimlaneClient` to make the `username` and `password` `__init__` params optional, then adds a new optional `access_token` parameter to the end of the parameter list to avoid breaking any existing customer code that uses only positional parameters.

A new `SwimlaneTokenAuth` class has been added to support personal access token authentication in the driver. This class is then used whenever an access token is supplied to `SwimlaneClient` instead of a username and password. When `Requests` invokes the class, a request is then made to `api/user/authorize` with the access token provided as a header in order to validate it and to return information about the user. A [separate pull request](https://github.com/swimlane/platform-dotnet/pull/514) has been opened to update this API endpoint to work with access tokens.

If a username and password are supplied instead of an access token, we fall back to using the existing `SwimlaneAuth` class, which has been renamed to `SwimlaneJwtAuth` in this PR to maintain clarity.

Since all authentication parameters for `SwimlaneClient.__init__` are now optional, parameter validation has been added for these parameters. If a username/password pair or an access token are not supplied then a `ValueError` is raised to the caller.

## Related Pull Requests

- [API Support for Authorizing Access Tokens](https://github.com/swimlane/platform-dotnet/pull/514)