### PR TITLE
SPT-4302 SSL Verify fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('./README.rst') as f:
 
 
 setup(
-    version="4.1.1",
+    version="4.1.2",
     name="swimlane",
     author="Swimlane LLC",
     author_email="info@swimlane.com",

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -17,6 +17,7 @@ from swimlane.core.resolver import SwimlaneResolver
 from swimlane.core.resources.usergroup import User
 from swimlane.exceptions import SwimlaneHTTP400Error, InvalidSwimlaneProductVersion
 from swimlane.utils.version import get_package_version, compare_versions
+from swimlane.core.wrappedsession import WrappedSession
 
 # Disable insecure request warnings
 urllib3.disable_warnings()
@@ -104,7 +105,7 @@ class Swimlane(object):
 
         self._default_timeout = default_timeout
 
-        self._session = requests.Session()
+        self._session = WrappedSession()
         self._session.verify = verify_ssl
 
         if username is not None and password is not None:

--- a/swimlane/core/wrappedsession.py
+++ b/swimlane/core/wrappedsession.py
@@ -1,0 +1,12 @@
+import requests
+
+class WrappedSession(requests.Session):
+    """A wrapper for requests.Session to override 'verify' property, ignoring REQUESTS_CA_BUNDLE environment variable.
+
+    This is a workaround for https://github.com/kennethreitz/requests/issues/3829 (will be fixed in requests 3.0.0)
+    """
+    def merge_environment_settings(self, url, proxies, stream, verify, *args, **kwargs):
+        if self.verify is False:
+            verify = False
+
+        return super(WrappedSession, self).merge_environment_settings(url, proxies, stream, verify, *args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from swimlane.core.resources.report import Report
 def mock_swimlane():
     """Return a mock Swimlane client"""
     # Patch around SwimlaneAuth.authenticate sending request, and manually assign a User instance
-    with mock.patch('swimlane.core.client.requests.Session', mock.MagicMock()):
+    with mock.patch('swimlane.core.client.WrappedSession', mock.MagicMock()):
         with mock.patch.object(SwimlaneJwtAuth, 'authenticate'):
             swimlane = Swimlane('http://host', 'admin', 'password', verify_server_version=False)
             swimlane._Swimlane__settings = {


### PR DESCRIPTION
Wrapping the request session object to work around a request bug when `REQUESTS_CA_BUNDLE` is set.

See https://github.com/kennethreitz/requests/issues/3829 for more info.