### PR TITLE
SPT-4287 Write to read only fields

### DIFF
--- a/docs/examples/client.rst
+++ b/docs/examples/client.rst
@@ -149,6 +149,27 @@ most often accessed will be kept in the cache longer than less-frequently access
 Resource caching can provide a big performance boost when requesting the same resources multiple times, especially when
 performing multiple searches or accessing references fields pointing to the same set of records.
 
+Write to Read Only Fields
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To enable the ability to set fields that have been marked Read-Only in the application builder, you can set the
+`write_to_read_only` parameter when initializing the Swimlane client.
+
+.. code-block:: python
+
+    from swimlane import Swimlane
+
+    swimlane = Swimlane(
+        '192.168.1.1',
+        'username',
+        'password',
+        write_to_read_only=True)
+
+    app = swimlane.apps.get(id='abc...123')
+    record = app.records.get(id='def...456')
+
+    record['Read-Only Field'] = "New Value"
+    record.save()
 
 Custom Direct Requests
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -90,7 +90,8 @@ class Swimlane(object):
             default_timeout=60,
             verify_server_version=True,
             resource_cache_size=0,
-            access_token=None
+            access_token=None,
+            write_to_read_only=False
     ):
         self.__verify_auth_params(username, password, access_token)
 
@@ -102,6 +103,8 @@ class Swimlane(object):
 
         self.__settings = None
         self.__user = None
+
+        self._read_only = write_to_read_only
 
         self._default_timeout = default_timeout
 

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -105,7 +105,7 @@ class Swimlane(object):
         self.__settings = None
         self.__user = None
 
-        self._read_only = write_to_read_only
+        self._write_to_read_only = write_to_read_only
 
         self._default_timeout = default_timeout
 

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -45,6 +45,7 @@ class Swimlane(object):
         resource_cache_size (int): Maximum number of each resource type to keep in memory cache. Set 0 to disable
             caching. Disabled by default
         access_token (str): Authentication token, used in lieu of a username and password
+        write_to_read_only (bool): Enable the ability to write to Read-only fields
 
     Attributes:
         host (pyuri.URI): Full RFC-1738 URL pointing to Swimlane host

--- a/swimlane/core/fields/base/field.py
+++ b/swimlane/core/fields/base/field.py
@@ -100,7 +100,7 @@ class Field(SwimlaneResolver):
 
     def validate_value(self, value):
         """Validate value is an acceptable type during set_python operation"""
-        if self.readonly:
+        if self.readonly and self._swimlane._read_only:
             raise ValidationError(self.record, "Cannot set readonly field '{}'".format(self.name))
         if value not in (None, self._unset):
             if self.supported_types and not isinstance(value, tuple(self.supported_types)):

--- a/swimlane/core/fields/base/field.py
+++ b/swimlane/core/fields/base/field.py
@@ -100,7 +100,7 @@ class Field(SwimlaneResolver):
 
     def validate_value(self, value):
         """Validate value is an acceptable type during set_python operation"""
-        if self.readonly and self._swimlane._read_only:
+        if self.readonly and not self._swimlane._read_only:
             raise ValidationError(self.record, "Cannot set readonly field '{}'".format(self.name))
         if value not in (None, self._unset):
             if self.supported_types and not isinstance(value, tuple(self.supported_types)):

--- a/swimlane/core/fields/base/field.py
+++ b/swimlane/core/fields/base/field.py
@@ -100,7 +100,7 @@ class Field(SwimlaneResolver):
 
     def validate_value(self, value):
         """Validate value is an acceptable type during set_python operation"""
-        if self.readonly and not self._swimlane._read_only:
+        if self.readonly and not self._swimlane._write_to_read_only:
             raise ValidationError(self.record, "Cannot set readonly field '{}'".format(self.name))
         if value not in (None, self._unset):
             if self.supported_types and not isinstance(value, tuple(self.supported_types)):

--- a/swimlane/core/fields/text.py
+++ b/swimlane/core/fields/text.py
@@ -1,4 +1,5 @@
 import six
+import json
 
 from .base import Field
 
@@ -14,6 +15,12 @@ class TextField(Field):
 
     def set_python(self, value):
         """Set field internal value from the python representation of field value"""
+
+        # json field handling
+        if self.input_type == "json":
+            if value is not None and not isinstance(value, self.supported_types):
+                value = json.dumps(value, indent=4)
+            self.readonly = False
         
         # hook exists to stringify before validation
 

--- a/swimlane/core/fields/text.py
+++ b/swimlane/core/fields/text.py
@@ -20,7 +20,6 @@ class TextField(Field):
         if self.input_type == "json":
             if value is not None and not isinstance(value, self.supported_types):
                 value = json.dumps(value, indent=4)
-            self.readonly = False
         
         # hook exists to stringify before validation
 

--- a/tests/resources/test_record.py
+++ b/tests/resources/test_record.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import pendulum
 
 import mock
 import pytest
@@ -120,6 +121,20 @@ class TestRecord(object):
             assert error.app is mock_record.app
         else:
             raise RuntimeError
+
+    def test_read_only(self, mock_swimlane, mock_record):
+        """Testing writing to a read only field"""
+
+        now = pendulum.now()
+        try:
+            mock_record['Datetime (Read-only)'] = now
+        except ValidationError as error:
+            assert mock_record['Datetime (Read-only)'] == None
+
+        mock_swimlane._write_to_read_only = True
+        mock_record['Datetime (Read-only)'] = now
+        assert mock_record['Datetime (Read-only)'] == now
+
 
     def test_iteration(self, mock_record):
         """Test that iterating over a record yields field names and their values like dict.items()"""


### PR DESCRIPTION
Enables the ability to write to read only fields via a parameter of the driver.  Also added in better handling for json fields.

Updated documentation as well.