### PR TITLE
[SPT-5997] Add Record PATCH endpoint support

### DIFF
--- a/swimlane/core/fields/base/field.py
+++ b/swimlane/core/fields/base/field.py
@@ -113,7 +113,9 @@ class Field(SwimlaneResolver):
     def _set(self, value):
         """Default setter used for both representations unless overridden"""
         self._value = value
-        self.record._raw['values'][self.id] = self.get_swimlane()
+        swimlane_value = self.get_swimlane()
+        self.record._raw['values'][self.id] = swimlane_value
+        return self.id, swimlane_value
 
     def set_python(self, value):
         """Set field internal value from the python representation of field value"""

--- a/swimlane/core/fields/base/field.py
+++ b/swimlane/core/fields/base/field.py
@@ -113,9 +113,7 @@ class Field(SwimlaneResolver):
     def _set(self, value):
         """Default setter used for both representations unless overridden"""
         self._value = value
-        swimlane_value = self.get_swimlane()
-        self.record._raw['values'][self.id] = swimlane_value
-        return self.id, swimlane_value
+        self.record._raw['values'][self.id] = self.get_swimlane()
 
     def set_python(self, value):
         """Set field internal value from the python representation of field value"""

--- a/swimlane/core/fields/base/field.py
+++ b/swimlane/core/fields/base/field.py
@@ -50,6 +50,10 @@ class Field(SwimlaneResolver):
         """Return best python representation of field value"""
         return self._get()
 
+    def get_batch_representation(self):
+        """Return best batch process representation of field value"""
+        return self._get()
+
     def get_swimlane(self):
         """Return best swimlane representation of field value"""
         return self.cast_to_swimlane(self._get())

--- a/swimlane/core/fields/usergroup.py
+++ b/swimlane/core/fields/usergroup.py
@@ -102,6 +102,10 @@ class UserGroupField(MultiSelectField):
             )
         )
 
+    def get_batch_representation(self):
+        """Return best batch process representation of field value"""
+        return self.get_swimlane()
+
     def set_swimlane(self, value):
         """Workaround for reports returning an empty usergroup field as a single element list with no id/name"""
         if value == [{"$type": "Core.Models.Utilities.UserGroupSelection, Core"}]:

--- a/swimlane/core/fields/valueslist.py
+++ b/swimlane/core/fields/valueslist.py
@@ -32,6 +32,10 @@ class ValuesListField(MultiSelectField):
                     )
                 )
 
+    def get_batch_representation(self):
+        """Return best batch process representation of field value"""
+        return self.get_swimlane()
+
     def cast_to_python(self, value):
         """Store actual value as internal representation"""
         if value is not None:

--- a/swimlane/core/resources/record.py
+++ b/swimlane/core/resources/record.py
@@ -29,7 +29,7 @@ class Record(APIResource):
 
         self.__app = app
 
-        self.__pending = {}
+        self.__altered_fields = {}
 
         self.is_new = self._raw.get('isNew', False)
 
@@ -78,7 +78,7 @@ class Record(APIResource):
     def __setitem__(self, field_name, value):
         field = self.get_field(field_name)
         field.set_python(value)
-        self.__pending[field.id] = field.get_swimlane()
+        self.__altered_fields[field.id] = 1
 
     def __getitem__(self, field_name):
         return self.get_field(field_name).get_python()
@@ -206,7 +206,7 @@ class Record(APIResource):
             copy_raw
         )
 
-        self.__pending = {}
+        self.__altered_fields = {}
 
     def patch(self):
         """Patch record on Swimlane server
@@ -218,7 +218,8 @@ class Record(APIResource):
             raise ValueError('Cannot patch a new Record')
 
         copy_raw = copy.copy(self._raw)
-        copy_raw['values'] = self.__pending
+
+        copy_raw['values'] = {k:v for (k,v) in copy_raw['values'].items() if k in self.__altered_fields}
 
         self.validate()
 
@@ -228,7 +229,7 @@ class Record(APIResource):
             copy_raw
         )
 
-        self.__pending = {}
+        self.__altered_fields = {}
 
     def delete(self):
         """Delete record from Swimlane server

--- a/swimlane/core/resources/record.py
+++ b/swimlane/core/resources/record.py
@@ -217,7 +217,7 @@ class Record(APIResource):
 
         pending_values = {k: self.get_field(k).get_batch_representation() for (k, v) in self}
         patch_values = {
-            self.get_field(k).id: pending_values[k] for k in pending_values.keys() & self.__existing_values
+            self.get_field(k).id: pending_values[k] for k in set(pending_values) & set(self.__existing_values)
             if pending_values[k] != self.__existing_values[k]
         }
 

--- a/swimlane/core/resources/record.py
+++ b/swimlane/core/resources/record.py
@@ -206,6 +206,8 @@ class Record(APIResource):
             copy_raw
         )
 
+        self.__pending = {}
+
     def patch(self):
         """Patch record on Swimlane server
 

--- a/swimlane/core/resources/record.py
+++ b/swimlane/core/resources/record.py
@@ -76,8 +76,9 @@ class Record(APIResource):
         return str(self.tracking_id)
 
     def __setitem__(self, field_name, value):
-        field_id, swimlane_value = self.get_field(field_name).set_python(value)
-        self.__pending[field_id] = swimlane_value
+        field = self.get_field(field_name)
+        field.set_python(value)
+        self.__pending[field.id] = field.get_swimlane()
 
     def __getitem__(self, field_name):
         return self.get_field(field_name).get_python()

--- a/tests/resources/test_record.py
+++ b/tests/resources/test_record.py
@@ -48,25 +48,77 @@ class TestRecord(object):
 
             mock_request.return_value.json.return_value = mock_record._raw
 
-            mock_record['TcpIPUtils - Geo Country Name'] = 'France'
+            mock_record['Action'] = 'test'
+            mock_record.patch()
+            mock_request.assert_called_with(
+                'patch',
+                'app/{}/record/{}'.format(mock_record.app.id, mock_record.id),
+                json={'$type': 'Core.Models.Record.Record, Core','actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'allowed': [],'applicationId': '58e4bb4407637a0e4c4f9873','applicationRevision': 0.0,'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]},'createdDate': '0001-01-01T00:00:00','disabled': False,'id': '58ebb22807637a02d4a14bd6','isNew': False,'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'modifiedDate': '0001-01-01T00:00:00','referencedByIds': [],'referencedRecordIds': [],'sessionTimeSpent': 0,'timeTrackingEnabled': True,'totalTimeSpent': 0,'trackingId': 7.0,
+                      'values': {
+                          'arnd6': 'test'
+                      }, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
+
+            mock_record['Numeric List'] = [1, 2.3]
+            mock_record.patch()
+            mock_request.assert_called_with(
+                'patch',
+                'app/{}/record/{}'.format(mock_record.app.id, mock_record.id),
+                json={'$type': 'Core.Models.Record.Record, Core','actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'allowed': [],'applicationId': '58e4bb4407637a0e4c4f9873','applicationRevision': 0.0,'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]},'createdDate': '0001-01-01T00:00:00','disabled': False,'id': '58ebb22807637a02d4a14bd6','isNew': False,'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'modifiedDate': '0001-01-01T00:00:00','referencedByIds': [],'referencedRecordIds': [],'sessionTimeSpent': 0,'timeTrackingEnabled': True,'totalTimeSpent': 0,'trackingId': 7.0,
+                      'values': {
+                          'azvbz': [1, 2.3]
+                      }, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
+
+            mock_record['Text List'] = ['a', 'b']
+            mock_record.patch()
+            mock_request.assert_called_with(
+                'patch',
+                'app/{}/record/{}'.format(mock_record.app.id, mock_record.id),
+                json={'$type': 'Core.Models.Record.Record, Core','actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'allowed': [],'applicationId': '58e4bb4407637a0e4c4f9873','applicationRevision': 0.0,'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]},'createdDate': '0001-01-01T00:00:00','disabled': False,'id': '58ebb22807637a02d4a14bd6','isNew': False,'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'modifiedDate': '0001-01-01T00:00:00','referencedByIds': [],'referencedRecordIds': [],'sessionTimeSpent': 0,'timeTrackingEnabled': True,'totalTimeSpent': 0,'trackingId': 7.0,
+                      'values': {
+                          'ajvrh': ['a', 'b'],
+                      }, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
+
+            mock_record['Last Updated By'].id = 'u2'
+            mock_record['Last Updated By'].name = 'other'
+            mock_record.patch()
+            mock_request.assert_called_with(
+                'patch',
+                'app/{}/record/{}'.format(mock_record.app.id, mock_record.id),
+                json={'$type': 'Core.Models.Record.Record, Core','actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'allowed': [],'applicationId': '58e4bb4407637a0e4c4f9873','applicationRevision': 0.0,'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]},'createdDate': '0001-01-01T00:00:00','disabled': False,'id': '58ebb22807637a02d4a14bd6','isNew': False,'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'modifiedDate': '0001-01-01T00:00:00','referencedByIds': [],'referencedRecordIds': [],'sessionTimeSpent': 0,'timeTrackingEnabled': True,'totalTimeSpent': 0,'trackingId': 7.0,
+                      'values': {
+                          'a11mn': {
+                              '$type': 'Core.Models.Utilities.UserGroupSelection, Core',
+                              'id': 'u2',
+                              'name': 'other'
+                          }
+                      }, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
+
+            mock_record['Values List'].deselect('Option 1')
+            mock_record['Values List'].select('Option 2')
+            mock_record.patch()
+            mock_request.assert_called_with(
+                'patch',
+                'app/{}/record/{}'.format(mock_record.app.id, mock_record.id),
+                json={'$type': 'Core.Models.Record.Record, Core','actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'allowed': [],'applicationId': '58e4bb4407637a0e4c4f9873','applicationRevision': 0.0,'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]},'createdDate': '0001-01-01T00:00:00','disabled': False,'id': '58ebb22807637a02d4a14bd6','isNew': False,'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'modifiedDate': '0001-01-01T00:00:00','referencedByIds': [],'referencedRecordIds': [],'sessionTimeSpent': 0,'timeTrackingEnabled': True,'totalTimeSpent': 0,'trackingId': 7.0,
+                      'values': {
+                          'arlrt': [{
+                              '$type': 'Core.Models.Record.ValueSelection, Core',
+                              'id': '58fae4eafef0eead26dee65c',
+                              'value': 'Option 2'
+                          }]
+                      }, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
+
             mock_record['Incident Closed'] = None
             mock_record.patch()
-
             mock_request.assert_called_with(
                 'patch',
                 'app/{}/record/{}'.format(mock_record.app.id, mock_record.id),
-                json={'$type': 'Core.Models.Record.Record, Core', 'actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'}, 'allowed': [], 'applicationId': '58e4bb4407637a0e4c4f9873', 'applicationRevision': 0.0, 'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]}, 'createdDate': '0001-01-01T00:00:00', 'disabled': False, 'id': '58ebb22807637a02d4a14bd6', 'isNew': False, 'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'}, 'modifiedDate': '0001-01-01T00:00:00', 'referencedByIds': [], 'referencedRecordIds': [], 'sessionTimeSpent': 0, 'timeTrackingEnabled': True, 'totalTimeSpent': 0, 'trackingId': 7.0, 'values': {'a2ybt': 'France', 'a365t': None}, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
+                json={'$type': 'Core.Models.Record.Record, Core','actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'allowed': [],'applicationId': '58e4bb4407637a0e4c4f9873','applicationRevision': 0.0,'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]},'createdDate': '0001-01-01T00:00:00','disabled': False,'id': '58ebb22807637a02d4a14bd6','isNew': False,'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'},'modifiedDate': '0001-01-01T00:00:00','referencedByIds': [],'referencedRecordIds': [],'sessionTimeSpent': 0,'timeTrackingEnabled': True,'totalTimeSpent': 0,'trackingId': 7.0,
+                      'values': {
+                          'a365t': None,
+                      }, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
 
-            mock_record['TcpIPUtils - DNS'] = '8.8.8.8'
-            mock_record.patch()
-
-            # ensure that we're only sending the changes since the last patch
-            mock_request.assert_called_with(
-                'patch',
-                'app/{}/record/{}'.format(mock_record.app.id, mock_record.id),
-                json={'$type': 'Core.Models.Record.Record, Core', 'actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'}, 'allowed': [], 'applicationId': '58e4bb4407637a0e4c4f9873', 'applicationRevision': 0.0, 'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]}, 'createdDate': '0001-01-01T00:00:00', 'disabled': False, 'id': '58ebb22807637a02d4a14bd6', 'isNew': False, 'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'}, 'modifiedDate': '0001-01-01T00:00:00', 'referencedByIds': [], 'referencedRecordIds': [], 'sessionTimeSpent': 0, 'timeTrackingEnabled': True, 'totalTimeSpent': 0, 'trackingId': 7.0, 'values': {'amjd0': '8.8.8.8'}, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
-
-            assert mock_request.call_count == 2
+            assert mock_request.call_count == 6
 
     def test_delete(self, mock_swimlane, mock_record):
         """Test record can be deleted when not new and that deleted records lose their ID but maintain their fields"""

--- a/tests/resources/test_record.py
+++ b/tests/resources/test_record.py
@@ -40,6 +40,33 @@ class TestRecord(object):
                 assert mock_validate.call_count == 2
                 assert mock_request.call_count == 1
 
+    def test_patch(self, mock_swimlane, mock_record):
+        """Test patch endpoint called with correct args"""
+
+        with mock.patch.object(mock_swimlane, 'request') as mock_request:
+
+            mock_request.return_value.json.return_value = mock_record._raw
+
+            mock_record['TcpIPUtils - Geo Country Name'] = 'France'
+            mock_record['Incident Closed'] = None
+            mock_record.patch()
+
+            mock_request.assert_called_with(
+                'patch',
+                'app/{}/record/{}'.format(mock_record.app.id, mock_record.id),
+                json={'$type': 'Core.Models.Record.Record, Core', 'actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'}, 'allowed': [], 'applicationId': '58e4bb4407637a0e4c4f9873', 'applicationRevision': 0.0, 'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]}, 'createdDate': '0001-01-01T00:00:00', 'disabled': False, 'id': '58ebb22807637a02d4a14bd6', 'isNew': False, 'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'}, 'modifiedDate': '0001-01-01T00:00:00', 'referencedByIds': [], 'referencedRecordIds': [], 'sessionTimeSpent': 0, 'timeTrackingEnabled': True, 'totalTimeSpent': 0, 'trackingId': 7.0, 'values': {'a2ybt': 'France', 'a365t': None}, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
+
+            mock_record['TcpIPUtils - DNS'] = '8.8.8.8'
+            mock_record.patch()
+
+            # ensure that we're only sending the changes since the last patch
+            mock_request.assert_called_with(
+                'patch',
+                'app/{}/record/{}'.format(mock_record.app.id, mock_record.id),
+                json={'$type': 'Core.Models.Record.Record, Core', 'actionsExecuted': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'}, 'allowed': [], 'applicationId': '58e4bb4407637a0e4c4f9873', 'applicationRevision': 0.0, 'comments': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.Comments, Core]], mscorlib]], mscorlib', 'a3uau': [{'$type': 'Core.Models.Record.Comments, Core', 'createdByUser': {'$type': 'Core.Models.Utilities.UserGroupSelection, Core', 'id': '58de1d1c07637a0264c0ca6a', 'name': 'admin'}, 'createdDate': '2017-04-19T18:40:25.529Z', 'message': 'Example comment'}]}, 'createdDate': '0001-01-01T00:00:00', 'disabled': False, 'id': '58ebb22807637a02d4a14bd6', 'isNew': False, 'linkedData': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Object, mscorlib]], mscorlib'}, 'modifiedDate': '0001-01-01T00:00:00', 'referencedByIds': [], 'referencedRecordIds': [], 'sessionTimeSpent': 0, 'timeTrackingEnabled': True, 'totalTimeSpent': 0, 'trackingId': 7.0, 'values': {'amjd0': '8.8.8.8'}, 'visualizations': {'$type': 'System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[Core.Models.Record.VisualizationData, Core]], mscorlib]], mscorlib'}})
+
+            assert mock_request.call_count == 2
+
     def test_delete(self, mock_swimlane, mock_record):
         """Test record can be deleted when not new and that deleted records lose their ID but maintain their fields"""
         with mock.patch.object(mock_swimlane, 'request') as mock_request:


### PR DESCRIPTION
Allows for the following interactions with a record:
```
record = app.records.get(tracking_id='5997-1')
record['Existing'] = 'overwrite'
record['ToRemove'] = None
record.patch()
```

Where the call to `.patch()` sends the following payload to the new PATCH endpoint for Record:
```
{
  '$type': 'Core.Models.Record.Record, Core',
  'id': 'r1',
  ...
  'values': {
    'existing-id': 'overwrite',
    'remove-id': null
  }
}
```