### PR TITLE
SPT-5882: Make travis build upload to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,10 @@ deploy:
   access_key_id: $S3_ACCESS_KEY
   secret_access_key: $S3_SECRET_KEY
   bucket: $S3_BUCKET
-  upload_dir: python_driver/mntest/10.1.2
+  upload_dir: python_driver/$TRAVIS_BRANCH/10.1.2
   local_dir: dist
   on:
     #tags: true
     branch: SPT-5882_make_travis_build_upload_to_s3
     repo: swimlane/swimlane-python
     condition: $TRAVIS_PYTHON_VERSION = '2.7'
-    

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ deploy:
     # Package uploaded is universal for Python 2 and 3, just only push to pip during one version build cycle
     condition: $TRAVIS_PYTHON_VERSION = '2.7'
 - provider: s3
+  region: $S3_REGION
   access_key_id: $S3_ACCESS_KEY
   secret_access_key: $S3_SECRET_KEY
   bucket: $S3_BUCKET

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ deploy:
   secret_access_key: $S3_SECRET_KEY
   bucket: $S3_BUCKET
   upload-dir: python_driver/mntest/10.1.2/
-  local_dir: dist/
+  glob: "dist/*"
   on:
     #tags: true
     branch: SPT-5882_make_travis_build_upload_to_s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ deploy:
   secret_access_key: $S3_SECRET_KEY
   bucket: $S3_BUCKET
   upload-dir: python_driver/mntest/10.1.2/
-  glob: "dist/swimlane-python-*-offline-installer-win_amd64-py27.pyz"
+  local_dir: dist
   on:
     #tags: true
     branch: SPT-5882_make_travis_build_upload_to_s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,12 @@ deploy:
 - provider: s3
   access_key_id: $S3_ACCESS_KEY
   secret_access_key: $S3_SECRET_KEY
-  region: us-west-2
-  bucket: "swimlane-builds"
+  bucket: "$S3_BUCKET"
   upload-dir: python_driver/mntest/10.1.2/
   glob: dist/swimlane-python-*-offline-installer-win_amd64-py27.pyz
   skip_cleanup: true
   on:
     #tags: true
+    branch: SPT-5882_make_travis_build_upload_to_s3
     repo: swimlane/swimlane-python
     condition: $TRAVIS_PYTHON_VERSION = '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ deploy:
   secret_access_key: $S3_SECRET_KEY
   bucket: $S3_BUCKET
   upload-dir: python_driver/mntest/10.1.2/
-  glob: dist/swimlane-python-*-offline-installer-win_amd64-py27.pyz
+  glob: "dist/swimlane-python-*-offline-installer-win_amd64-py27.pyz"
   on:
     #tags: true
     branch: SPT-5882_make_travis_build_upload_to_s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,9 @@ deploy:
   access_key_id: $S3_ACCESS_KEY
   secret_access_key: $S3_SECRET_KEY
   bucket: $S3_BUCKET
-  upload_dir: python_driver/$TRAVIS_BRANCH/10.1.2
+  upload_dir: python_driver/$TRAVIS_TAG
   local_dir: dist
   on:
-    #tags: true
-    branch: SPT-5882_make_travis_build_upload_to_s3
+    tags: true
     repo: swimlane/swimlane-python
     condition: $TRAVIS_PYTHON_VERSION = '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,15 @@ deploy:
     repo: swimlane/swimlane-python
     # Package uploaded is universal for Python 2 and 3, just only push to pip during one version build cycle
     condition: $TRAVIS_PYTHON_VERSION = '2.7'
+- provider: s3
+  access_key_id: $S3_ACCESS_KEY
+  secret_access_key: $S3_SECRET_KEY
+  region: us-west-2
+  bucket: "swimlane-builds"
+  upload-dir: python_driver/mntest/10.1.2/
+  glob: dist/swimlane-python-*-offline-installer-win_amd64-py27.pyz
+  skip_cleanup: true
+  on:
+    #tags: true
+    repo: swimlane/swimlane-python
+    condition: $TRAVIS_PYTHON_VERSION = '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ deploy:
   access_key_id: $S3_ACCESS_KEY
   secret_access_key: $S3_SECRET_KEY
   bucket: $S3_BUCKET
-  upload-dir: python_driver/mntest/10.1.2/
-  glob: "dist/*"
+  upload_dir: python_driver/mntest/10.1.2/
+  local_dir: dist
+  glob: dist/*
   on:
     #tags: true
     branch: SPT-5882_make_travis_build_upload_to_s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,18 @@ script: py.test -v --cov=swimlane --cov-report=xml
 after_script: python-codacy-coverage -r coverage.xml
 before_deploy: python offline_installer/build_installer.py
 deploy:
+- provider: s3
+  region: $S3_REGION
+  access_key_id: $S3_ACCESS_KEY
+  secret_access_key: $S3_SECRET_KEY
+  bucket: $S3_BUCKET
+  upload-dir: python_driver/mntest/10.1.2/
+  local_dir: dist/
+  on:
+    #tags: true
+    branch: SPT-5882_make_travis_build_upload_to_s3
+    repo: swimlane/swimlane-python
+    condition: $TRAVIS_PYTHON_VERSION = '2.7'
 - provider: releases
   api_key:
     secure: cJWvvnIxF67OgjUfpahgLbsQC/XEjgwkX1Ohb32FY9rhKEJcqjU46+31N9vGKkPMFi42K0/lrfuM6w9oCiM4IyOM3y8AGro5XoMwyIMBvglyS0HHPF5gVNu+WLj4M2Zx47MechgHcAxqw8NMYMqxIIx5vBzHabWnMt2Z16Q9r4olcwBxzLqJHowchACU9XIY9EH+i3OonDRdyUScAQq1aw4BJfkdZKy3KUl3H2/yyRlJmhLHJ6/XaypWrdPCprs65Rtfw20M7bDa2+EJLq3GkzBYflWvW2qYYcJoZZUD3YnqApEgxkPtaYF+Wt6sjENiqHEyrOxA0OVapbLskm8aN66lFRr/n/7WeJaPPaN39Qs2ToVBH5AYLiq2id+/9sq0tM35XolM7bFrIB8tad2u/0+uWnt7E+g/26b0KFLRX0ReZGBL+zHYTM2AGlkpUZpKlaGlUd7HNbdTUjBnQYMeGA/O/QJ0ExPRjRjdDw/VZrW6zk83ynqAg5qmpNV/tG/oTj4h/e7yfMvJpDuFZ8DkVs9RRdnY462AOToby6oooM+b012fY9UykMgfcEXeq4YNiUnvdsmNXFGyv0s+/VvIZdcl6QGNV8dy//qLUdhQ3s59AI4Q4YxH318pkoQDEl7kxbSvcf5dkE7W29/6SUulPc4+2hK5cmQcddPASsHmrNY=
@@ -31,16 +43,4 @@ deploy:
     tags: true
     repo: swimlane/swimlane-python
     # Package uploaded is universal for Python 2 and 3, just only push to pip during one version build cycle
-    condition: $TRAVIS_PYTHON_VERSION = '2.7'
-- provider: s3
-  region: $S3_REGION
-  access_key_id: $S3_ACCESS_KEY
-  secret_access_key: $S3_SECRET_KEY
-  bucket: $S3_BUCKET
-  upload-dir: python_driver/mntest/10.1.2/
-  local_dir: dist
-  on:
-    #tags: true
-    branch: SPT-5882_make_travis_build_upload_to_s3
-    repo: swimlane/swimlane-python
     condition: $TRAVIS_PYTHON_VERSION = '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,6 @@ script: py.test -v --cov=swimlane --cov-report=xml
 after_script: python-codacy-coverage -r coverage.xml
 before_deploy: python offline_installer/build_installer.py
 deploy:
-- provider: s3
-  edge: true
-  region: $S3_REGION
-  access_key_id: $S3_ACCESS_KEY
-  secret_access_key: $S3_SECRET_KEY
-  bucket: $S3_BUCKET
-  upload_dir: python_driver/mntest/10.1.2/
-  local_dir: dist
-  on:
-    #tags: true
-    branch: SPT-5882_make_travis_build_upload_to_s3
-    repo: swimlane/swimlane-python
-    condition: $TRAVIS_PYTHON_VERSION = '2.7'
 - provider: releases
   api_key:
     secure: cJWvvnIxF67OgjUfpahgLbsQC/XEjgwkX1Ohb32FY9rhKEJcqjU46+31N9vGKkPMFi42K0/lrfuM6w9oCiM4IyOM3y8AGro5XoMwyIMBvglyS0HHPF5gVNu+WLj4M2Zx47MechgHcAxqw8NMYMqxIIx5vBzHabWnMt2Z16Q9r4olcwBxzLqJHowchACU9XIY9EH+i3OonDRdyUScAQq1aw4BJfkdZKy3KUl3H2/yyRlJmhLHJ6/XaypWrdPCprs65Rtfw20M7bDa2+EJLq3GkzBYflWvW2qYYcJoZZUD3YnqApEgxkPtaYF+Wt6sjENiqHEyrOxA0OVapbLskm8aN66lFRr/n/7WeJaPPaN39Qs2ToVBH5AYLiq2id+/9sq0tM35XolM7bFrIB8tad2u/0+uWnt7E+g/26b0KFLRX0ReZGBL+zHYTM2AGlkpUZpKlaGlUd7HNbdTUjBnQYMeGA/O/QJ0ExPRjRjdDw/VZrW6zk83ynqAg5qmpNV/tG/oTj4h/e7yfMvJpDuFZ8DkVs9RRdnY462AOToby6oooM+b012fY9UykMgfcEXeq4YNiUnvdsmNXFGyv0s+/VvIZdcl6QGNV8dy//qLUdhQ3s59AI4Q4YxH318pkoQDEl7kxbSvcf5dkE7W29/6SUulPc4+2hK5cmQcddPASsHmrNY=
@@ -45,3 +32,17 @@ deploy:
     repo: swimlane/swimlane-python
     # Package uploaded is universal for Python 2 and 3, just only push to pip during one version build cycle
     condition: $TRAVIS_PYTHON_VERSION = '2.7'
+- provider: s3
+  edge: true
+  region: $S3_REGION
+  access_key_id: $S3_ACCESS_KEY
+  secret_access_key: $S3_SECRET_KEY
+  bucket: $S3_BUCKET
+  upload_dir: python_driver/mntest/10.1.2
+  local_dir: dist
+  on:
+    #tags: true
+    branch: SPT-5882_make_travis_build_upload_to_s3
+    repo: swimlane/swimlane-python
+    condition: $TRAVIS_PYTHON_VERSION = '2.7'
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ deploy:
 - provider: s3
   access_key_id: $S3_ACCESS_KEY
   secret_access_key: $S3_SECRET_KEY
-  bucket: "$S3_BUCKET"
+  bucket: $S3_BUCKET
   upload-dir: python_driver/mntest/10.1.2/
   glob: dist/swimlane-python-*-offline-installer-win_amd64-py27.pyz
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ after_script: python-codacy-coverage -r coverage.xml
 before_deploy: python offline_installer/build_installer.py
 deploy:
 - provider: s3
+  edge: true
   region: $S3_REGION
   access_key_id: $S3_ACCESS_KEY
   secret_access_key: $S3_SECRET_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ deploy:
   user: swimlane
   distributions: sdist bdist_wheel
   password: $PIP_PASSWORD
+  skip_cleanup: true
   on:
     tags: true
     repo: swimlane/swimlane-python
@@ -38,7 +39,6 @@ deploy:
   bucket: $S3_BUCKET
   upload-dir: python_driver/mntest/10.1.2/
   glob: dist/swimlane-python-*-offline-installer-win_amd64-py27.pyz
-  skip_cleanup: true
   on:
     #tags: true
     branch: SPT-5882_make_travis_build_upload_to_s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ deploy:
   bucket: $S3_BUCKET
   upload_dir: python_driver/mntest/10.1.2/
   local_dir: dist
-  glob: dist/*
   on:
     #tags: true
     branch: SPT-5882_make_travis_build_upload_to_s3


### PR DESCRIPTION
Updates the travis-ci build to upload the package from the python 2.7 build to S3.