### PR TITLE
SPT-6628 fix version breakdown

### DIFF
--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -262,7 +262,7 @@ class Swimlane(object):
             # Post product/build version separation
             # This will handle <product_version>+<build_version>+<build_number>
             # or <build_version>+<build_number> formats of the version
-            return return self.version.split(version_separator)[-2]
+            return self.version.split(version_separator)[-2]
         # Pre product/build version separation
         return self.product_version
 

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -262,9 +262,7 @@ class Swimlane(object):
             # Post product/build version separation
             # This will handle <product_version>+<build_version>+<build_number>
             # or <build_version>+<build_number> formats of the version
-            versionList = self.version.split(version_separator)
-            versionList.reverse()
-            return versionList[1]
+            return return self.version.split(version_separator)[-2]
         # Pre product/build version separation
         return self.product_version
 

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -260,7 +260,11 @@ class Swimlane(object):
         version_separator = '+'
         if version_separator in self.version:
             # Post product/build version separation
-            return self.version.split(version_separator)[1]
+            # This will handle <product_version>+<build_version>+<build_number>
+            # or <build_version>+<build_number> formats of the version
+            versionList = self.version.split(version_separator)
+            versionList.reverse()
+            return versionList[1]
         # Pre product/build version separation
         return self.product_version
 


### PR DESCRIPTION
This will fix the version being in either of the 2 formats that Swimlane has used.
<product_version>+<build_version>+<build_number>
<build_version>+<build_number>