### PR TITLE
TA-71 fix version of pytest-html

### DIFF
--- a/functional_tests/requirements.txt
+++ b/functional_tests/requirements.txt
@@ -1,4 +1,4 @@
 Faker==0.8.15
 pytest==3.5.0
-pytest-hmtl==1.22.1
+pytest-hmtl>=1.22.1
 swimlane


### PR DESCRIPTION
pytest-html supports 2.x through 1.22.1, but does not support 3.8 until later, so settign to a min value of 1.22.1, allowing for newer when using a newer python version.