### PR TITLE
TA-71 cleanup pytest.fixure

### DIFF
--- a/functional_tests/conftest.py
+++ b/functional_tests/conftest.py
@@ -22,22 +22,18 @@ def pytest_addoption(parser):
                      help="pass in to not verify the server version with the pydriver version")
 
 
-@pytest.fixture(scope='session')
 def api_url(pytestconfig):
     return pytestconfig.getoption("--url")
 
 
-@pytest.fixture(scope='session')
 def api_user(pytestconfig):
     return pytestconfig.getoption("--user").lower()
 
 
-@pytest.fixture(scope='session')
 def api_pass(pytestconfig):
     return pytestconfig.getoption("--pass")
 
 
-@pytest.fixture(scope='session')
 def api_verifyVersion(pytestconfig):
     return pytestconfig.getoption("--skipverify")
 


### PR DESCRIPTION
Removing the pytest.fixture calls on the functions for the arguments used in the tests.