### PR TITLE
TA-71 removing swimlane dependency

### DIFF
--- a/functional_tests/requirements.txt
+++ b/functional_tests/requirements.txt
@@ -1,4 +1,3 @@
 Faker==0.8.15
 pytest>=3.5.0
 pytest-html>=1.22.1
-swimlane


### PR DESCRIPTION
Removing the dependency to the pip version of the pyDriver, for supporting test against code not released yet.