### PR TITLE
Removed causing part in yeld

### DIFF
--- a/swimlane/core/resources/record.py
+++ b/swimlane/core/resources/record.py
@@ -59,7 +59,7 @@ class Record(APIResource):
         self._fields = {}
         self.__premap_fields()
 
-        self.__existing_values = {k: self.get_field(k).get_batch_representation() for (k, v) in self}
+        self.__existing_values = {k: self.get_field(k).get_batch_representation() for k in self}
         self._comments_modified = False
 
         self.locked = False
@@ -91,7 +91,7 @@ class Record(APIResource):
 
     def __iter__(self):
         for field_name, field in six.iteritems(self._fields):
-            yield field_name, field.get_python()
+            yield field_name
 
     def __hash__(self):
         return hash((self.id, self.app))


### PR DESCRIPTION
Hi there

As described in the ticket https://support.swimlane.com/support/tickets/7023 we had the problem, that the search stopped working from version 10.1.3 on. We had problems to have you reproducing the problem since it was tied to specific data on our side. I hence took the liberty of forking your library.

The investigation showed, that our linked applications (see Ticket, entry from the 10th of August) cause the issue. In line 62 of record.py there's an iteration over all fields. The generator in __iter__ called field.get_python(). This call lead to a infinite loop, since a given record1 of App1 points to a given record2 of App2 points to the record1 of App 1 and so on. Including some debugging statements resulted in smth like this:
(<class 'swimlane.core.resources.app.App'>, 'id', 'aJ7PHD19fSvGeduuF')              MissionControl
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aVC2Oo2L3qZudKaiU')        MC-386
(<class 'swimlane.core.resources.app.App'>, 'id', 'aPgWzppJNfcALxlrg')              Customer Management    
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aYnF7qwiOWAoujZ86')        CM-1
(<class 'swimlane.core.resources.app.App'>, 'id', 'acrwv2XppnZJfj_Hk')              Customer Specific Message Templates
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aMFBni2nXS2aYwWbL')        none
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aRUBEIQYNXO_Y43JL')        none
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aZJdTsQ8Fcpqv0d7S')        IGCT-27
(<class 'swimlane.core.resources.app.App'>, 'id', 'aPgWzppJNfcALxlrg')              Customer Management 
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aYnF7qwiOWAoujZ86')        CM-1
(<class 'swimlane.core.resources.app.App'>, 'id', 'acrwv2XppnZJfj_Hk')              Customer Specific Message Templates
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aMFBni2nXS2aYwWbL')        none
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aRUBEIQYNXO_Y43JL')        none
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aZJdTsQ8Fcpqv0d7S')        IGCT-27
(<class 'swimlane.core.resources.app.App'>, 'id', 'aPgWzppJNfcALxlrg')              Customer Management    
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aYnF7qwiOWAoujZ86')        CM-1
(<class 'swimlane.core.resources.app.App'>, 'id', 'acrwv2XppnZJfj_Hk')              Customer Specific Message Templates
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aMFBni2nXS2aYwWbL')        none
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aRUBEIQYNXO_Y43JL')        none
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aZJdTsQ8Fcpqv0d7S')        IGCT-27
...


(<class 'swimlane.core.resources.record.Record'>, 'id', 'abLprrTYneTuFxP3E')        MC-300
(<class 'swimlane.core.resources.app.App'>, 'id', 'aeGhvd7AXYl2b_3OJ')              Messages
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aDAVK_hVpnZd7_Fgp')        IGCC-66
(<class 'swimlane.core.resources.app.App'>, 'id', 'aJ7PHD19fSvGeduuF')              MissionControl
(<class 'swimlane.core.resources.record.Record'>, 'id', 'abLprrTYneTuFxP3E')        MC-300
(<class 'swimlane.core.resources.app.App'>, 'id', 'aeGhvd7AXYl2b_3OJ')              Messages
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aDAVK_hVpnZd7_Fgp')
(<class 'swimlane.core.resources.app.App'>, 'id', 'aJ7PHD19fSvGeduuF')
(<class 'swimlane.core.resources.record.Record'>, 'id', 'abLprrTYneTuFxP3E')
(<class 'swimlane.core.resources.app.App'>, 'id', 'aeGhvd7AXYl2b_3OJ')
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aDAVK_hVpnZd7_Fgp')
(<class 'swimlane.core.resources.app.App'>, 'id', 'aJ7PHD19fSvGeduuF')
(<class 'swimlane.core.resources.record.Record'>, 'id', 'abLprrTYneTuFxP3E')
(<class 'swimlane.core.resources.app.App'>, 'id', 'aeGhvd7AXYl2b_3OJ')
(<class 'swimlane.core.resources.record.Record'>, 'id', 'aDAVK_hVpnZd7_Fgp')
(<class 'swimlane.core.resources.app.App'>, 'id', 'aJ7PHD19fSvGeduuF')
(<class 'swimlane.core.resources.record.Record'>, 'id', 'abLprrTYneTuFxP3E')

Since I was not able to find a usage of the part "field.get_python()", I removed it. All unit tests were green afterwards. But I did not run the functional test, since the setup would cost me another couple of hours.

So please double check this change and run the functional tests. It might also be good to include our data constellation into the tests (most likely into the functional tests). Please let me know, if you want a db dump for a reproducer.

Feel free to contact me at any time and tnx for the review, Ingo