### PR TITLE
SPT-7920

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ Session.vim
 # IDE
 /.idea/
 venv/
+venv3/
 .vscode/
 
 # functional Testing:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pendulum==2.1.2
 pyjwt>=1.6,<1.7
 pyuri>=0.3,<0.4
 requests[security]>=2,<3
-six==1.12.0
+six>=1.12.0
 sortedcontainers>=1.5,<1.6
 shortid==0.1.2

--- a/swimlane/core/fields/base/field.py
+++ b/swimlane/core/fields/base/field.py
@@ -46,6 +46,10 @@ class Field(SwimlaneResolver):
         """Default getter used for both representations unless overridden"""
         return self._value
 
+    def get_item(self):
+        """Return best python representation of field value for get attribute method"""
+        return self.get_python()
+
     def get_python(self):
         """Return best python representation of field value"""
         return self._get()

--- a/swimlane/core/fields/reference.py
+++ b/swimlane/core/fields/reference.py
@@ -1,8 +1,6 @@
 import logging
-
 import six
 from sortedcontainers import SortedDict
-
 from swimlane.core.fields.base import CursorField, FieldCursor
 from swimlane.core.resources.record import Record
 from swimlane.exceptions import ValidationError, SwimlaneHTTP400Error
@@ -15,7 +13,6 @@ class ReferenceCursor(FieldCursor):
 
     def __init__(self, *args, **kwargs):
         super(ReferenceCursor, self).__init__(*args, **kwargs)
-
         self._elements = self._elements or SortedDict()
 
     @property
@@ -25,9 +22,7 @@ class ReferenceCursor(FieldCursor):
 
     def _evaluate(self):
         """Scan for orphaned records and retrieve any records that have not already been grabbed"""
-
         retrieved_records = SortedDict()
-
         for record_id, record in six.iteritems(self._elements):
             if record is self._field._unset:
                 # Record has not yet been retrieved, get it
@@ -41,7 +36,6 @@ class ReferenceCursor(FieldCursor):
             retrieved_records[record_id] = record
 
         self._elements = retrieved_records
-
         return self._elements.values()
 
     def add(self, record):
@@ -65,7 +59,6 @@ class ReferenceField(CursorField):
 
     def __init__(self, *args, **kwargs):
         super(ReferenceField, self).__init__(*args, **kwargs)
-
         self.__target_app_id = self.field_definition['targetId']
         self.__target_app = None
 
@@ -130,31 +123,21 @@ class ReferenceField(CursorField):
             self.validate_value(record)
             records[record.id] = record
 
-        return_value = self._set(records)
+        self._set(records)
         self.record._raw['values'][self.id] = self.get_swimlane()
-
-        return return_value
 
     def get_swimlane(self):
         """Return list of record ids"""
         value = super(ReferenceField, self).get_swimlane()
         if value:
             ids = list(value.keys())
+            return ids if self.multiselect else ids[0]
 
-            if self.multiselect:
-                return ids
-
-            return ids[0]
-
-        return None
-
-    def get_python(self):
+    def get_item(self):
         """Return cursor if multi-select, direct value if single-select"""
         cursor = super(ReferenceField, self).get_python()
-
         if self.multiselect:
             return cursor
-
         else:
             try:
                 return cursor[0]

--- a/swimlane/core/resources/record.py
+++ b/swimlane/core/resources/record.py
@@ -1,9 +1,7 @@
 import copy
 from functools import total_ordering
-
 import pendulum
 import six
-
 from swimlane.core.resources.base import APIResource
 from swimlane.core.resources.usergroup import UserGroup, User
 from swimlane.exceptions import UnknownField, ValidationError
@@ -84,7 +82,7 @@ class Record(APIResource):
         self.get_field(field_name).set_python(value)
 
     def __getitem__(self, field_name):
-        return self.get_field(field_name).get_python()
+        return self.get_field(field_name).get_item()
 
     def __delitem__(self, field_name):
         self[field_name] = None
@@ -223,8 +221,7 @@ class Record(APIResource):
 
         copy_raw = copy.copy(self._raw)
 
-        pending_values = {k: self.get_field(
-            k).get_batch_representation() for (k, v) in self}
+        pending_values = {k: self.get_field(k).get_batch_representation() for (k, v) in self}
         patch_values = {
             self.get_field(k).id: pending_values[k] for k in set(pending_values) & set(self.__existing_values)
             if pending_values[k] != self.__existing_values[k]
@@ -382,7 +379,6 @@ class Record(APIResource):
 
         self._raw['allowed'] = allowed
 
-
     def lock(self):
         """
         Lock the record to the Current User.
@@ -395,8 +391,6 @@ class Record(APIResource):
         Args:
 
         """
-
-
         self.validate()
         response = self._swimlane.request(
             'post',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 import random
-
 import mock
 import pytest
-
 from swimlane.core.client import SwimlaneJwtAuth, Swimlane
 from swimlane.core.resources.app import App
 from swimlane.core.resources.record import Record

--- a/tests/fields/test_reference.py
+++ b/tests/fields/test_reference.py
@@ -31,7 +31,7 @@ class TestReferenceField(object):
         with mock.patch.object(mock_swimlane.apps, 'get', return_value=mock_record.app):
             field = mock_record.get_field(self.single_field_name)
 
-            assert field.get_python() is None
+            assert field.get_item() is None
 
             # Assert setting to None adds the field's key to raw values
             field.set_python(None)

--- a/tests/resources/test_record.py
+++ b/tests/resources/test_record.py
@@ -1,10 +1,8 @@
-import copy
 import json
 import pendulum
-
 import mock
 import pytest
-
+from swimlane.core.fields.reference import ReferenceCursor
 from swimlane.core.adapters import RecordRevisionAdapter
 from swimlane.core.resources.record import Record, record_factory
 from swimlane.exceptions import UnknownField, ValidationError
@@ -227,7 +225,10 @@ class TestRecord(object):
 
         for field_name, field_value in mock_record:
             num_fields += 1
-            assert field_value == mock_record[field_name]
+            if isinstance(field_value, ReferenceCursor) and not field_value._field.multiselect:
+                assert mock_record[field_name] is None
+            else:
+                assert field_value == mock_record[field_name]
 
         assert num_fields > 0
 


### PR DESCRIPTION
 Implemented late value retrieval from cursor. It was too early before for single select fields.
Customer was having problems retrieving records when there was circular references on them. It was found out that during record initialization single select for referenced records was not stored as cursor, but as a value that in turn forced retrieval of the record and that record forced circular resolution backwards. Code was changed to always pre-populate with cursor and only on getting attribute resolve it to record and value.