### PR TITLE
SPT-9672 update doc for incorrect code showing app lookup by acronym

### DIFF
--- a/docs/examples/resources.rst
+++ b/docs/examples/resources.rst
@@ -26,7 +26,7 @@ from other apps will fail to be retrieved.
 
 .. code-block:: python
 
-    app = swimlane.apps.get(acronym='APP')
+    app = swimlane.apps.get(name='Target App')
 
     # Get by Tracking ID
     record_from_tracking = app.records.get(tracking_id='APP-1')


### PR DESCRIPTION
The documentation is incorrect, stating that an application can be looked up by its acronym. It can only be looked up by its ID or Name.