### PR TITLE
SPT-11003: Update import_content to work with new tracking endpoint

### DIFF
--- a/functional_tests/conftest.py
+++ b/functional_tests/conftest.py
@@ -140,8 +140,8 @@ class Helpers:
             'file': (file_name, bytes_stream, 'application/octet-stream'),
             'runInBackground': False
         }
-        trackingId = self.swimlane_instance.request('post', 'content/import', files=files).text
-        response = self.swimlane_instance.request('get', 'content/import/%s/status' % trackingId).json()
+        tracking_id = self.swimlane_instance.request('post', 'content/import', files=files).text
+        response = self.swimlane_instance.request('get', 'content/import/%s/status' % tracking_id).json()
         if response.get('success'):
             for app in response.get('entities').get('application'):
                 self.appIds.append(app.get('id'))

--- a/functional_tests/conftest.py
+++ b/functional_tests/conftest.py
@@ -137,9 +137,11 @@ class Helpers:
             file_stream = file_handle.read()
         bytes_stream = BytesIO(file_stream)
         files = {
-            'file': (file_name, bytes_stream, 'application/octet-stream')
+            'file': (file_name, bytes_stream, 'application/octet-stream'),
+            'runInBackground': False
         }
-        response = self.swimlane_instance.request('post', 'content/import', files=files).json()
+        trackingId = self.swimlane_instance.request('post', 'content/import', files=files).text
+        response = self.swimlane_instance.request('get', 'content/import/%s/status' % trackingId).json()
         if response.get('success'):
             for app in response.get('entities').get('application'):
                 self.appIds.append(app.get('id'))


### PR DESCRIPTION
conftest was failing while trying to import an SSP because it expected to get a ContentExchangeResult back instead of a tracking ID. Updated to work post-SPT-10343.