### PR TITLE
SPT-11003: Run import synchronously

### DIFF
--- a/functional_tests/conftest.py
+++ b/functional_tests/conftest.py
@@ -136,13 +136,15 @@ class Helpers:
         with open('{file_path}/content/{file_name}'.format(file_name=file_name, file_path=file_path), 'rb') as file_handle:
             file_stream = file_handle.read()
         bytes_stream = BytesIO(file_stream)
-        files = {
-            'file': (file_name, bytes_stream, 'application/octet-stream'),
+        file = {
+            'file': (file_name, bytes_stream, 'application/octet-stream')
+        }
+        data = {
             'runInBackground': False
         }
-        tracking_id = self.swimlane_instance.request('post', 'content/import', files=files).text
+        tracking_id = self.swimlane_instance.request('post', 'content/import', files=file, data=data).text
         response = self.swimlane_instance.request('get', 'content/import/%s/status' % tracking_id).json()
-        if response.get('success'):
+        if response.get('state') == 'Success':
             for app in response.get('entities').get('application'):
                 self.appIds.append(app.get('id'))
         else:


### PR DESCRIPTION
Last fix worked by chance - this update will run the import synchronously instead of as a background process (for real this time) and check the correct value in the status endpoint's response to see if it was successful.