### PR TITLE
Revert "Namor/SPT-14498:Bulk record create endpoint does not return a list of created records"

### DIFF
--- a/functional_tests/driver_tests/test_records_bulk_adaptor.py
+++ b/functional_tests/driver_tests/test_records_bulk_adaptor.py
@@ -32,15 +32,6 @@ class TestRecordAdaptorBulkCreate:
             ('Text', 'equals', None), ('Numeric', 'equals', None))
         assert len(emptyRecords) == 4+initialEmptyRecords
 
-    def test_record_bulk_create_check_TrackingIds(helpers):
-        initialEmptyRecords = len(pytest.app.records.search(
-            ('Text', 'equals', None), ('Numeric', 'equals', None)))
-        recIds = pytest.app.records.bulk_create({'Text': 'Happy Joy'}, {'Text': 'Happy Joy'}, {
-                                       'Text': 'Happy Joy'}, {'Text': 'Happy Joy'})
-        emptyRecords = pytest.app.records.search(
-            ('Text', 'equals', None), ('Numeric', 'equals', None))
-        assert len(recIds) == 4
-
     def test_record_bulk_create_with_values(helpers):
         initalRecords = len(pytest.app.records.search(
             ('Text', 'equals', 'Happy Joy'), ('Numeric', 'equals', None)))
@@ -457,7 +448,7 @@ class TestRecordAdaptorBulkModifyClear:
 
     def test_record_bulk_modify_clear_references(helpers):
         baseText = "Has Reference"
-        pytest.app.records.bulk_create({'Text': baseText}, {'Text': baseText},{
+        pytest.app.records.bulk_create({'Text': baseText}, {'Text': baseText}, {
                                        'Text': baseText}, {'Text': baseText})
         targetApp = pytest.swimlane_instance.apps.get(
             name="PYTHON-Helpers Target App")

--- a/swimlane/core/adapters/record.py
+++ b/swimlane/core/adapters/record.py
@@ -210,11 +210,11 @@ class RecordAdapter(AppResolver):
 
             new_records.append(record)
 
-        return self._swimlane.request(
+        self._swimlane.request(
             'post',
             'app/{}/record/batch'.format(self._app.id),
             json=[r._raw for r in new_records]
-        ).json()
+        )
 
     # pylint: disable=too-many-branches
     @requires_swimlane_version('2.17')


### PR DESCRIPTION
Reverts swimlane/swimlane-python#147

These changes has to be reverted as the tests failing in the PR's