### PR TITLE
SPT-15811: Send entityIds parameter to SSP import endpoint

### DIFF
--- a/functional_tests/driver_tests/test_record_task_execution.py
+++ b/functional_tests/driver_tests/test_record_task_execution.py
@@ -4,7 +4,7 @@ from swimlane.exceptions import SwimlaneException
 @pytest.fixture(autouse=True, name='app', scope='module')
 def my_fixture(helpers):
     # setup stuff
-    helpers.import_content('basic_task_app.ssp')
+    helpers.import_content('basic_task_app.ssp', ['aFgmZM_gL89BGPKaZ', 'aF_jCzUS1zxgyDV8p', 'aGJfrazDjqlBf1fi4', 'aGdcVCS_QhYhLqqGK', 'aGxZ8oxm7YMC2e_pa', 'aHGVnQRXpP9hkTANq'])
     yield helpers.swimlane_instance.apps.get(name='Basic Task App')
     # teardown stuff
     helpers.cleanupData()

--- a/functional_tests/driver_tests/test_record_task_execution.py
+++ b/functional_tests/driver_tests/test_record_task_execution.py
@@ -4,7 +4,7 @@ from swimlane.exceptions import SwimlaneException
 @pytest.fixture(autouse=True, name='app', scope='module')
 def my_fixture(helpers):
     # setup stuff
-    helpers.import_content('basic_task_app.ssp', ['aFgmZM_gL89BGPKaZ', 'aF_jCzUS1zxgyDV8p', 'aGJfrazDjqlBf1fi4', 'aGdcVCS_QhYhLqqGK', 'aGxZ8oxm7YMC2e_pa', 'aHGVnQRXpP9hkTANq'])
+    helpers.import_content('basic_task_app.ssp')
     yield helpers.swimlane_instance.apps.get(name='Basic Task App')
     # teardown stuff
     helpers.cleanupData()


### PR DESCRIPTION
SPT-15310 introduced a new parameter to the content/import endpoint which contains a list of the IDs of the entities which should be imported. SPT-15811 adjusted the default behavior for an empty list, and now sending no IDs results in importing no entities. That is a breaking change, and this PR fixes the pydriver tests, which are using an SSP to shortcut test setup but need to include the new parameter in order for anything to be imported.