### PR TITLE
SPT-6995: PyDriver code has deprecated calls that are on their way out.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pyjwt>=2.4.0
 pyuri>=0.3,<0.4
 requests[security]>=2,<3
 six>=1.12.0
-sortedcontainers>=1.5,<1.6
+sortedcontainers==2.4.0
 shortid==0.1.2

--- a/swimlane/core/cache.py
+++ b/swimlane/core/cache.py
@@ -7,7 +7,10 @@ A ResourcesCache instance is provided on all Swimlane client instances automatic
 import copy
 import functools
 import logging
-from collections import defaultdict
+try:
+    from collections.abc import defaultdict
+except ImportError:
+    from collections import defaultdict
 
 from cachetools import LFUCache
 

--- a/swimlane/core/fields/list.py
+++ b/swimlane/core/fields/list.py
@@ -1,4 +1,7 @@
-from collections import defaultdict
+try:
+    from collections.abc import defaultdict
+except ImportError:
+    from collections import defaultdict
 from copy import deepcopy
 from numbers import Number
 


### PR DESCRIPTION
# Devex Change Request

## Change Comments

I updated some packages to delete all the warnings

## Solution description

I updated the sortedcontainers library to the version 2.4.0 and modified the collections imports.

Evidences:
_**Current:**_
![Screen Shot 2022-12-07 at 10 03 41 PM](https://user-images.githubusercontent.com/100230626/206353804-4669ae76-8cbb-47d6-a71e-8006e657a6bc.png)

_**Fixed:**_
![Screen Shot 2022-12-07 at 10 11 18 PM](https://user-images.githubusercontent.com/100230626/206354668-eb3c6f07-89a2-4e31-ac24-49d1abe4e8df.png)


## Checklist

<!-- Strike out any steps that do not apply -->

_**PR is ready for code review and approval when each box is checked.**_

_All steps are required, when applicable. ~Strikeout~ formatting indicates a step is not applicable to this change set._

- [x] Ticket referenced in PR title (ex. _SPT-XXX: Short summary of change_)