### PR TITLE
SPT- 6031 (bug) - sends non whole numbers for user limit

### DIFF
--- a/functional_tests/driver_tests/test_users_groups_adaptor.py
+++ b/functional_tests/driver_tests/test_users_groups_adaptor.py
@@ -26,17 +26,23 @@ class TestUserAdaptor:
         swimUsers = pytest.swimlane_instance.users.list(limit=maxUsers)
         assert len(swimUsers) == maxUsers
 
-    @pytest.mark.xfail(reason="SPT-6031: Sending a string for the max count should throw an error.")
     def test_users_list_count_limit_not_valid_string(helpers):
-        invalidMaxUsers = 'Hello'
-        swimUsers = pytest.swimlane_instance.users.list(limit=invalidMaxUsers)
-        assert len(swimUsers) == invalidMaxUsers
+        stringLimit = 'Hello'
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.users.list(limit=stringLimit)
+        assert str(excinfo.value) == 'Limit should be a whole number'
 
-    @pytest.mark.xfail(reason="SPT-6031: Sending a floating point for the max count should throw an error.")
+    def test_users_list_count_limit_not_valid_empty_string(helpers):
+        stringLimit = ''
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.users.list(limit=stringLimit)
+        assert str(excinfo.value) == 'Limit should be a whole number'
+
     def test_users_list_count_limit_not_valid_float(helpers):
-        floatMaxUsers = 1.75
-        swimUsers = pytest.swimlane_instance.users.list(limit=floatMaxUsers)
-        assert len(swimUsers) == floatMaxUsers
+        floatLimit = 5.5
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.users.list(limit=floatLimit)
+        assert str(excinfo.value) == 'Limit should be a whole number'
 
     def test_users_get_by_id(helpers):
         swimUser = pytest.swimlane_instance.users.get(id=pytest.tempUser['id'])
@@ -115,18 +121,23 @@ class TestGroupAdaptor:
         swimGroups = pytest.swimlane_instance.groups.list(limit=maxGroups)
         assert len(swimGroups) == maxGroups
 
-    @pytest.mark.xfail(reason="SPT-6031: Sending a string for the max count should throw an error.")
     def test_groups_list_count_limit_not_valid_string(helpers):
-        invalidMaxGroups = 'Hello'
-        swimGroups = pytest.swimlane_instance.users.list(
-            limit=invalidMaxGroups)
-        assert len(swimGroups) == invalidMaxGroups
+        stringLimit = 'Hello'
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.groups.list(limit=stringLimit)
+        assert str(excinfo.value) == 'Limit should be a whole number'
 
-    @pytest.mark.xfail(reason="SPT-6031: Sending a floating point for the max count should throw an error.")
+    def test_groups_list_count_limit_not_valid_empty_string(helpers):
+        stringLimit = ''
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.groups.list(limit=stringLimit)
+        assert str(excinfo.value) == 'Limit should be a whole number'
+
     def test_groups_list_count_limit_not_valid_float(helpers):
-        floatMaxGroups = 1.75
-        swimGroups = pytest.swimlane_instance.users.list(limit=floatMaxGroups)
-        assert len(swimGroups) == floatMaxGroups
+        floatLimit = 5.5
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.groups.list(limit=floatLimit)
+        assert str(excinfo.value) == 'Limit should be a whole number'
 
     def test_grouprs_get_by_id(helpers):
         swimGroup = pytest.swimlane_instance.groups.get(

--- a/functional_tests/driver_tests/test_users_groups_adaptor.py
+++ b/functional_tests/driver_tests/test_users_groups_adaptor.py
@@ -30,19 +30,31 @@ class TestUserAdaptor:
         stringLimit = 'Hello'
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.list(limit=stringLimit)
-        assert str(excinfo.value) == 'Limit should be a whole number'
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
 
     def test_users_list_count_limit_not_valid_empty_string(helpers):
         stringLimit = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.list(limit=stringLimit)
-        assert str(excinfo.value) == 'Limit should be a whole number'
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
 
     def test_users_list_count_limit_not_valid_float(helpers):
         floatLimit = 5.5
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.list(limit=floatLimit)
-        assert str(excinfo.value) == 'Limit should be a whole number'
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
+
+    def test_users_list_count_limit_not_valid_negative_int(helpers):
+        negativeIntLimit = -3
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.users.list(limit=negativeIntLimit)
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
+
+    def test_users_list_count_limit_not_valid_zero(helpers):
+        zeroLimit = 0
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.users.list(limit=zeroLimit)
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
 
     def test_users_get_by_id(helpers):
         swimUser = pytest.swimlane_instance.users.get(id=pytest.tempUser['id'])
@@ -125,19 +137,31 @@ class TestGroupAdaptor:
         stringLimit = 'Hello'
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.list(limit=stringLimit)
-        assert str(excinfo.value) == 'Limit should be a whole number'
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
 
     def test_groups_list_count_limit_not_valid_empty_string(helpers):
         stringLimit = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.list(limit=stringLimit)
-        assert str(excinfo.value) == 'Limit should be a whole number'
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
 
     def test_groups_list_count_limit_not_valid_float(helpers):
         floatLimit = 5.5
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.list(limit=floatLimit)
-        assert str(excinfo.value) == 'Limit should be a whole number'
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
+
+    def test_groups_list_count_limit_not_valid_zero(helpers):
+        zeroLimit = 0
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.groups.list(limit=zeroLimit)
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
+
+    def test_groups_list_count_limit_not_valid_negative_int(helpers):
+        negativeIntLimit = -3
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.groups.list(limit=negativeIntLimit)
+        assert str(excinfo.value) == 'Limit should be a positive whole number greater than 0'
 
     def test_grouprs_get_by_id(helpers):
         swimGroup = pytest.swimlane_instance.groups.get(

--- a/swimlane/core/adapters/usergroup.py
+++ b/swimlane/core/adapters/usergroup.py
@@ -41,7 +41,7 @@ class GroupAdapter(SwimlaneResolver):
             ValueError: If limit is not of type integer or None
         """
 
-        if type(limit) is int or limit is None:
+        if isinstance(limit, int) or limit is None:
             return GroupListCursor(swimlane=self._swimlane, limit=limit)
 
         raise ValueError('Limit should be a whole number')
@@ -114,7 +114,7 @@ class UserAdapter(SwimlaneResolver):
             ValueError: If limit is not of type integer or None
         """
 
-        if type(limit) is int or limit is None:
+        if isinstance(limit, int) or limit is None:
             return UserListCursor(swimlane=self._swimlane, limit=limit)
 
         raise ValueError('Limit should be a whole number')

--- a/swimlane/core/adapters/usergroup.py
+++ b/swimlane/core/adapters/usergroup.py
@@ -41,10 +41,10 @@ class GroupAdapter(SwimlaneResolver):
             ValueError: If limit is not of type integer or None
         """
 
-        if isinstance(limit, int) or limit is None:
+        if (isinstance(limit, int) and limit > 0) or limit is None:
             return GroupListCursor(swimlane=self._swimlane, limit=limit)
 
-        raise ValueError('Limit should be a whole number')
+        raise ValueError('Limit should be a positive whole number greater than 0')
 
     @check_cache(Group)
     @one_of_keyword_only('id', 'name')
@@ -114,10 +114,10 @@ class UserAdapter(SwimlaneResolver):
             ValueError: If limit is not of type integer or None
         """
 
-        if isinstance(limit, int) or limit is None:
+        if (isinstance(limit, int) and limit > 0) or limit is None:
             return UserListCursor(swimlane=self._swimlane, limit=limit)
 
-        raise ValueError('Limit should be a whole number')
+        raise ValueError('Limit should be a positive whole number greater than 0')
 
     @check_cache(User)
     @one_of_keyword_only('id', 'display_name')

--- a/swimlane/core/adapters/usergroup.py
+++ b/swimlane/core/adapters/usergroup.py
@@ -37,8 +37,14 @@ class GroupAdapter(SwimlaneResolver):
 
         Returns:
             :class:`list` of :class:`~swimlane.core.resources.usergroup.Group`: List of all Groups
+        Raises:
+            ValueError: If limit is not of type integer or None
         """
-        return GroupListCursor(self._swimlane, limit=limit)
+
+        if type(limit) is int or limit is None:
+            return GroupListCursor(swimlane=self._swimlane, limit=limit)
+
+        raise ValueError('Limit should be a whole number')
 
     @check_cache(Group)
     @one_of_keyword_only('id', 'name')
@@ -103,8 +109,15 @@ class UserAdapter(SwimlaneResolver):
 
         Returns:
             :class:`UserListCursor`: Paginated cursor yielding :class:`User` instances
+
+        Raises:
+            ValueError: If limit is not of type integer or None
         """
-        return UserListCursor(swimlane=self._swimlane, limit=limit)
+
+        if type(limit) is int or limit is None:
+            return UserListCursor(swimlane=self._swimlane, limit=limit)
+
+        raise ValueError('Limit should be a whole number')
 
     @check_cache(User)
     @one_of_keyword_only('id', 'display_name')


### PR DESCRIPTION
- Add a guard that checks the limit param type for the list() method on both the user and group adapter
- Checks if the limit provided is None or integer, else a ValueError is raised with relevant message
- Updated xfail marked tests

Link to ticket: [SPT-6031](https://swimlane.atlassian.net/browse/SPT-6031)