### PR TITLE
SPT-9975: Cannot Set Numeric Field to 0 With Python Driver

### DIFF
--- a/swimlane/core/resources/record.py
+++ b/swimlane/core/resources/record.py
@@ -240,7 +240,7 @@ class Record(APIResource):
             if self.app.get_field_definition_by_id(field_id)['fieldType'] == 'attachment':
                 raise ValueError('Can not patch new attachments')
             # Use None for empty arrays to ensure field is removed from Record on PATCH
-            if not value:
+            if not value and value != 0:
                 patch_values[field_id] = None
 
         # $type needed here for dotnet to deserialize correctly


### PR DESCRIPTION
# Devex Change Request

## Change Comments

I updated the library to fix an error that occurs during the patch.

## Solution description

I updated the library to support a patch using a 0 value. Because previously we validated using if not value, but this validation is true when you sent a 0 as a value so I added an additional validation to resolve this issue.

Evidences:
_**Current:**_
https://user-images.githubusercontent.com/100230626/208474722-c774739e-5719-45cc-ac16-f47e9a6b68d4.mov

_**Fixed:**_
https://user-images.githubusercontent.com/100230626/208474146-3a15f1fb-12f6-46b0-a5b6-c0a7d5f933a4.mov


## Checklist

<!-- Strike out any steps that do not apply -->

_**PR is ready for code review and approval when each box is checked.**_

_All steps are required, when applicable. ~Strikeout~ formatting indicates a step is not applicable to this change set._

- [x] Ticket referenced in PR title (ex. _SPT-XXX: Short summary of change_)