### PR TITLE
SPT-6038 - get call for revision of apps and records does not validate param value

### DIFF
--- a/functional_tests/driver_tests/test_app_revision_adaptor.py
+++ b/functional_tests/driver_tests/test_app_revision_adaptor.py
@@ -32,7 +32,7 @@ class TestAppRevisionAdaptor:
         theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
         with pytest.raises(ValueError) as excinfo:
             theapp.revisions.get(-2)
-        assert str(excinfo.value) == pytest.py_ver_no_json()
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
 
     def test_app_get_too_large_number_revision(helpers):
         theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
@@ -40,31 +40,32 @@ class TestAppRevisionAdaptor:
             theapp.revisions.get(99)
         assert str(excinfo.value) == pytest.py_ver_no_json()
 
-    @pytest.mark.xfail(reason="SPT-6038: URL is being made with the string, throwing errors")
-    def test_app_get_invalid_revision(helpers):
+    def test_app_get_invalid_string_revision(helpers):
         theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
         with pytest.raises(ValueError) as excinfo:
             theapp.revisions.get('garbage')
-        assert str(excinfo.value) == pytest.py_ver_no_json()
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
 
-    # This grabs the newest version... not 2 or 3... or errors?
-    @pytest.mark.xfail(reason="SPT-6038:Grabbs latest versioninstead of throwing an error")
     def test_app_get_float_revision(helpers):
         theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
         with pytest.raises(ValueError) as excinfo:
             theapp.revisions.get(2.5)
-        assert str(excinfo.value) == 'No JSON object could be decoded'
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
 
-    @pytest.mark.xfail(reason="SPT-6038?: Attribute error 'list' object has no attribute 'get'")
     def test_app_get_empty_revision(helpers):
         theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
         with pytest.raises(ValueError) as excinfo:
             theapp.revisions.get('')
-        assert str(excinfo.value) == pytest.py_ver_no_json()
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
 
-    @pytest.mark.xfail(reason="SPT-6038: URL is being made with the None, throwing errors")
     def test_app_get_none_revision(helpers):
         theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
         with pytest.raises(ValueError) as excinfo:
             theapp.revisions.get(None)
-        assert str(excinfo.value) == pytest.py_ver_no_json()
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
+
+    def test_app_get_zero_revision(helpers):
+        theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
+        with pytest.raises(ValueError) as excinfo:
+            theapp.revisions.get(0)
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'

--- a/functional_tests/driver_tests/test_app_revision_adaptor.py
+++ b/functional_tests/driver_tests/test_app_revision_adaptor.py
@@ -28,6 +28,12 @@ class TestAppRevisionAdaptor:
         assert app_rev.revision_number == 2
         assert app_rev.version.description == pytest.app2.description
 
+    def test_app_get_specific_revision_float_only_zeros_after_decimal(helpers):
+        theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
+        app_rev = theapp.revisions.get(2.0)
+        assert app_rev.revision_number == 2.0
+        assert app_rev.version.description == pytest.app2.description
+
     def test_app_get_negative_number_revision(helpers):
         theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
         with pytest.raises(ValueError) as excinfo:

--- a/functional_tests/driver_tests/test_record_revision_adaptor.py
+++ b/functional_tests/driver_tests/test_record_revision_adaptor.py
@@ -1,4 +1,5 @@
 import pytest
+from requests import HTTPError
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -34,47 +35,51 @@ class TestRecordRevisionAdaptor:
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)
         record_rev = therecord.revisions.get(2)
         assert record_rev.revision_number == 2
-        assert record_rev.version.for_json() == pytest.record2
 
-    @pytest.mark.xfail(reason="SPT-6038: URL is being made with the negative number, throwing errors")
     def test_record_get_negative_number_revision(helpers):
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)
         with pytest.raises(ValueError) as excinfo:
             therecord.revisions.get(-2)
-        assert str(excinfo.value) == 'No JSON object could be decoded'
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
 
-    @pytest.mark.xfail(reason="SPT-6038: URL is being made with the large number, throwing errors")
     def test_record_get_too_large_number_revision(helpers):
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(HTTPError) as excinfo:
             therecord.revisions.get(99)
-        assert str(excinfo.value) == 'No JSON object could be decoded'
+        assert '404 Client Error: Not Found for url' in str(excinfo.value)
 
-    @pytest.mark.xfail(reason="SPT-6038: URL is being made with the garbage test, throwing errors")
-    def test_record_get_invalid_revision(helpers):
+    def test_app_get_too_large_number_revision(helpers):
+        theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
+        with pytest.raises(ValueError) as excinfo:
+            theapp.revisions.get(99)
+        assert str(excinfo.value) == pytest.py_ver_no_json()
+
+    def test_record_get_string_revision(helpers):
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)
         with pytest.raises(ValueError) as excinfo:
             therecord.revisions.get('garbage')
-        assert str(excinfo.value) == 'No JSON object could be decoded'
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
 
-    # This grabs the newest version... not 2 or 3... or errors?
-    @pytest.mark.xfail(reason="SPT-6038:Grabbs latest versioninstead of throwing an error")
     def test_record_get_float_revision(helpers):
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)
         with pytest.raises(ValueError) as excinfo:
             therecord.revisions.get(2.5)
-        assert str(excinfo.value) == 'No JSON object could be decoded'
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
 
-    @pytest.mark.xfail(reason="SPT-6038: Attribute error 'list' object has no attribute 'get'")
     def test_record_get_empty_revision(helpers):
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)
         with pytest.raises(ValueError) as excinfo:
             therecord.revisions.get('')
-        assert str(excinfo.value) == 'No JSON object could be decoded'
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
 
-    @pytest.mark.xfail(reason="SPT-6038: URL is being made with the None, throwing errors")
     def test_record_get_none_revision(helpers):
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)
         with pytest.raises(ValueError) as excinfo:
             therecord.revisions.get(None)
-        assert str(excinfo.value) == 'No JSON object could be decoded'
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'
+
+    def test_record_get_zero_revision(helpers):
+        therecord = pytest.app.records.get(id=pytest.baseRecord.id)
+        with pytest.raises(ValueError) as excinfo:
+            therecord.revisions.get(0)
+        assert str(excinfo.value) == 'The revision number must be a positive whole number greater than 0'

--- a/functional_tests/driver_tests/test_record_revision_adaptor.py
+++ b/functional_tests/driver_tests/test_record_revision_adaptor.py
@@ -35,6 +35,10 @@ class TestRecordRevisionAdaptor:
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)
         record_rev = therecord.revisions.get(2)
         assert record_rev.revision_number == 2
+    def test_record_get_specific_revision_float_only_zeros_after_decimal(helpers):
+        therecord = pytest.app.records.get(id=pytest.baseRecord.id)
+        record_rev = therecord.revisions.get(2.0)
+        assert record_rev.revision_number == 2.0
 
     def test_record_get_negative_number_revision(helpers):
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)
@@ -47,12 +51,6 @@ class TestRecordRevisionAdaptor:
         with pytest.raises(HTTPError) as excinfo:
             therecord.revisions.get(99)
         assert '404 Client Error: Not Found for url' in str(excinfo.value)
-
-    def test_app_get_too_large_number_revision(helpers):
-        theapp = pytest.swimlane_instance.apps.get(id=pytest.appid)
-        with pytest.raises(ValueError) as excinfo:
-            theapp.revisions.get(99)
-        assert str(excinfo.value) == pytest.py_ver_no_json()
 
     def test_record_get_string_revision(helpers):
         therecord = pytest.app.records.get(id=pytest.baseRecord.id)

--- a/swimlane/core/adapters/app_revision.py
+++ b/swimlane/core/adapters/app_revision.py
@@ -1,3 +1,5 @@
+import math
+
 from swimlane.core.cache import check_cache
 from swimlane.core.resolver import AppResolver
 from swimlane.core.resources.app_revision import AppRevision
@@ -28,14 +30,15 @@ class AppRevisionAdapter(AppResolver):
 
         Returns:
             AppRevision: The AppRevision for the given revision number.
-            Raises: When revision is not an integer or is less than 1
+            Raises: When revision is not an integer, a float NOT ending in ".0", or is less than 1
         """
 
-        if not isinstance(revision_number, int) or revision_number < 1:
-            raise ValueError('The revision number must be a positive whole number greater than 0')
+        if isinstance(revision_number, (int, float)):
+            if revision_number > 0 and revision_number % math.floor(revision_number) == 0:
+                key_value = AppRevision.get_unique_id(self._app.id, revision_number)
+                return self.__get(app_id_revision=key_value)
 
-        key_value = AppRevision.get_unique_id(self._app.id, revision_number)
-        return self.__get(app_id_revision=key_value)
+        raise ValueError('The revision number must be a positive whole number greater than 0')
 
     @check_cache(AppRevision)
     @one_of_keyword_only('app_id_revision')

--- a/swimlane/core/adapters/app_revision.py
+++ b/swimlane/core/adapters/app_revision.py
@@ -28,7 +28,12 @@ class AppRevisionAdapter(AppResolver):
 
         Returns:
             AppRevision: The AppRevision for the given revision number.
+            Raises: When revision is not an integer or is less than 1
         """
+
+        if not isinstance(revision_number, int) or revision_number < 1:
+            raise ValueError('The revision number must be a positive whole number greater than 0')
+
         key_value = AppRevision.get_unique_id(self._app.id, revision_number)
         return self.__get(app_id_revision=key_value)
 

--- a/swimlane/core/adapters/record_revision.py
+++ b/swimlane/core/adapters/record_revision.py
@@ -1,3 +1,5 @@
+import math
+
 from swimlane.core.resolver import AppResolver
 from swimlane.core.resources.record_revision import RecordRevision
 
@@ -27,13 +29,15 @@ class RecordRevisionAdapter(AppResolver):
 
         Returns:
             RecordRevision: The RecordRevision for the given revision number.
-            Raises: When revision is not an integer or is less than 1
+            Raises: When revision is not an integer, a float NOT ending in ".0", or is less than 1
         """
-        if not isinstance(revision_number, int) or revision_number < 1:
-            raise ValueError('The revision number must be a positive whole number greater than 0')
+        if isinstance(revision_number, (int, float)):
+            if revision_number > 0 and revision_number % math.floor(revision_number) == 0:
+                record_revision_raw = self._swimlane.request('get',
+                                                             'app/{0}/record/{1}/history/{2}'.format(self._app.id,
+                                                                                                     self.record.id,
+                                                                                                     revision_number)).json()
+                return RecordRevision(self._app, record_revision_raw)
 
-        record_revision_raw = self._swimlane.request('get',
-                                                     'app/{0}/record/{1}/history/{2}'.format(self._app.id,
-                                                                                             self.record.id,
-                                                                                             revision_number)).json()
-        return RecordRevision(self._app, record_revision_raw)
+
+        raise ValueError('The revision number must be a positive whole number greater than 0')

--- a/swimlane/core/adapters/record_revision.py
+++ b/swimlane/core/adapters/record_revision.py
@@ -27,7 +27,11 @@ class RecordRevisionAdapter(AppResolver):
 
         Returns:
             RecordRevision: The RecordRevision for the given revision number.
+            Raises: When revision is not an integer or is less than 1
         """
+        if not isinstance(revision_number, int) or revision_number < 1:
+            raise ValueError('The revision number must be a positive whole number greater than 0')
+
         record_revision_raw = self._swimlane.request('get',
                                                      'app/{0}/record/{1}/history/{2}'.format(self._app.id,
                                                                                              self.record.id,

--- a/tests/adapters/test_app_revision_adapter.py
+++ b/tests/adapters/test_app_revision_adapter.py
@@ -1,3 +1,5 @@
+import math
+
 import mock
 
 from swimlane.core.resources.app_revision import AppRevision
@@ -26,10 +28,12 @@ class TestAppRevisionAdapter(object):
         mock_response.status_code = 200
 
         with mock.patch.object(mock_swimlane, 'request', return_value=mock_response):
-            revision = mock_revision_app.revisions.get(raw_revision['revisionNumber'])
+            revision_as_int = math.floor(raw_revision['revisionNumber']);
+
+            revision = mock_revision_app.revisions.get(revision_as_int)
 
             mock_swimlane.request.assert_called_with('get', 'app/{0}/history/{1}'.format(mock_revision_app.id,
-                                                                                         raw_revision['revisionNumber']))
+                                                                                         revision_as_int))
 
             assert isinstance(revision, AppRevision)
             assert revision.revision_number is raw_revision['revisionNumber']


### PR DESCRIPTION
- For both the app and records GET revisions call, add guard that checks if revision value is an integer AND greater than 0
- If not, raises a ValueError and returns a specific response
- Update and add tests to both app and records adapter

Link to ticket [SPT-6038](https://swimlane.atlassian.net/browse/SPT-6038), which has a video attached demonstrating functionality

Examples of new error handling
![image](https://user-images.githubusercontent.com/10706131/209215124-16424486-edeb-4023-93ad-9d48e14426b9.png)

![image](https://user-images.githubusercontent.com/10706131/209215167-d3e252fc-6430-427e-b111-76551f4f0e00.png)

![image](https://user-images.githubusercontent.com/10706131/209215232-b9cd2ca6-1d5a-4e00-ad99-235485803455.png)

Examples of success

![image](https://user-images.githubusercontent.com/10706131/209215397-2d5f5566-4339-4f45-a718-db6f9dc48c69.png)

![image](https://user-images.githubusercontent.com/10706131/209215427-f8753727-e1cf-456a-8e92-83dfddf9efbc.png)

