### PR TITLE
SPT-6030: Looking up an app/record/user/group/etc, by name/id/refID/etc fail if the value being used is empty or None

### DIFF
--- a/functional_tests/driver_tests/test_apps_adaptor.py
+++ b/functional_tests/driver_tests/test_apps_adaptor.py
@@ -32,19 +32,29 @@ class TestAppsAdaptor:
             pytest.swimlane_instance.apps.get(id=randomID)
         assert str(excinfo.value) == 'No app with id "%s"' % randomID
 
-    @pytest.mark.xfail(reason="SPT-5944: Testing for randomID as empty does not give formal response (attributeError)")
     def test_get_by_empty_id(helpers):
-        randomID = ""
+        emptyID = ""
         with pytest.raises(ValueError) as excinfo:
-            pytest.swimlane_instance.apps.get(id=randomID)
-        assert str(excinfo.value) == 'No app with id "%s"' % randomID
+            pytest.swimlane_instance.apps.get(id=emptyID)
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+    
+    def test_get_by_null_id(helpers):
+        noneID = None
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.apps.get(id=noneID)
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
 
-    @pytest.mark.xfail(reason="SPT-5944: Testing for randomName as empty should check on value is empty")
     def test_get_by_empty_name(helpers):
-        randomName = ""
+        emptyName = ""
         with pytest.raises(ValueError) as excinfo:
-            pytest.swimlane_instance.apps.get(name=randomName)
-        assert str(excinfo.value) == 'No app with name "%s"' % randomName
+            pytest.swimlane_instance.apps.get(name=emptyName)
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+    
+    def test_get_by_null_name(helpers):
+        noneName = None
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.apps.get(name=noneName)
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
 
     def test_get_by_fake_name(helpers):
         randomName = pytest.fake.sentence()

--- a/functional_tests/driver_tests/test_apps_adaptor.py
+++ b/functional_tests/driver_tests/test_apps_adaptor.py
@@ -36,25 +36,25 @@ class TestAppsAdaptor:
         emptyID = ""
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.apps.get(id=emptyID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No id provided'
     
     def test_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.apps.get(id=noneID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No id provided'
 
     def test_get_by_empty_name(helpers):
         emptyName = ""
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.apps.get(name=emptyName)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No name provided'
     
     def test_get_by_null_name(helpers):
         noneName = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.apps.get(name=noneName)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No name provided'
 
     def test_get_by_fake_name(helpers):
         randomName = pytest.fake.sentence()

--- a/functional_tests/driver_tests/test_apps_adaptor.py
+++ b/functional_tests/driver_tests/test_apps_adaptor.py
@@ -36,25 +36,25 @@ class TestAppsAdaptor:
         emptyID = ""
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.apps.get(id=emptyID)
-        assert str(excinfo.value) == 'No id provided'
+        assert str(excinfo.value) == 'The value provided for the key "id" cannot be empty or None'
     
     def test_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.apps.get(id=noneID)
-        assert str(excinfo.value) == 'No id provided'
+        assert str(excinfo.value) == 'The value provided for the key "id" cannot be empty or None'
 
     def test_get_by_empty_name(helpers):
         emptyName = ""
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.apps.get(name=emptyName)
-        assert str(excinfo.value) == 'No name provided'
+        assert str(excinfo.value) == 'The value provided for the key "name" cannot be empty or None'
     
     def test_get_by_null_name(helpers):
         noneName = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.apps.get(name=noneName)
-        assert str(excinfo.value) == 'No name provided'
+        assert str(excinfo.value) == 'The value provided for the key "name" cannot be empty or None'
 
     def test_get_by_fake_name(helpers):
         randomName = pytest.fake.sentence()

--- a/functional_tests/driver_tests/test_records_adaptor.py
+++ b/functional_tests/driver_tests/test_records_adaptor.py
@@ -94,13 +94,13 @@ class TestRecordAdaptorGet:
         emptyID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.app.records.get(id=emptyID)
-        assert str(excinfo.value) == 'No id provided'
+        assert str(excinfo.value) == 'The value provided for the key "id" cannot be empty or None'
 
     def test_record_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.app.records.get(id=noneID)
-        assert str(excinfo.value) == 'No id provided'
+        assert str(excinfo.value) == 'The value provided for the key "id" cannot be empty or None'
 
     def test_record_get_by_random_tracking_id(helpers):
         randomID = pytest.fake.random_int()
@@ -113,13 +113,13 @@ class TestRecordAdaptorGet:
         emptyTrackingID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.app.records.get(tracking_id=emptyTrackingID)
-        assert str(excinfo.value) == 'No tracking_id provided'
+        assert str(excinfo.value) == 'The value provided for the key "tracking_id" cannot be empty or None'
 
     def test_record_get_by_null_trackingId(helpers):
         noneTrackingID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.app.records.get(tracking_id=noneTrackingID)
-        assert str(excinfo.value) == 'No tracking_id provided'
+        assert str(excinfo.value) == 'The value provided for the key "tracking_id" cannot be empty or None'
 
 class TestRecordAdaptorSearch:
     def test_record_search(helpers):

--- a/functional_tests/driver_tests/test_records_adaptor.py
+++ b/functional_tests/driver_tests/test_records_adaptor.py
@@ -94,13 +94,13 @@ class TestRecordAdaptorGet:
         emptyID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.app.records.get(id=emptyID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No id provided'
 
     def test_record_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.app.records.get(id=noneID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No id provided'
 
     def test_record_get_by_random_tracking_id(helpers):
         randomID = pytest.fake.random_int()
@@ -113,13 +113,13 @@ class TestRecordAdaptorGet:
         emptyTrackingID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.app.records.get(tracking_id=emptyTrackingID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No tracking_id provided'
 
     def test_record_get_by_null_trackingId(helpers):
         noneTrackingID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.app.records.get(tracking_id=noneTrackingID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No tracking_id provided'
 
 class TestRecordAdaptorSearch:
     def test_record_search(helpers):

--- a/functional_tests/driver_tests/test_records_adaptor.py
+++ b/functional_tests/driver_tests/test_records_adaptor.py
@@ -90,13 +90,17 @@ class TestRecordAdaptorGet:
         assert str(excinfo.value) == 'RecordNotFound:3002: Bad Request for url: %s/api/app/%s/record/%s' % (
             pytest.swimlane_instance.host, pytest.appid, randomID)
 
-    @pytest.mark.xfail(reason="SPT-6030: Fail when the lookup value is empty or None")
     def test_record_get_by_empty_id(helpers):
         emptyID = ''
-        with pytest.raises(exceptions.HTTPError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             pytest.app.records.get(id=emptyID)
-        assert str(excinfo.value) == 'RecordNotFound:3002: Bad Request for url: %s/api/app/%s/record/tracking/%s' % (
-            pytest.swimlane_instance.host, pytest.appid, emptyID)
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+
+    def test_record_get_by_null_id(helpers):
+        noneID = None
+        with pytest.raises(ValueError) as excinfo:
+            pytest.app.records.get(id=noneID)
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
 
     def test_record_get_by_random_tracking_id(helpers):
         randomID = pytest.fake.random_int()
@@ -105,14 +109,17 @@ class TestRecordAdaptorGet:
         assert str(excinfo.value) == 'RecordNotFound:3002: Bad Request for url: %s/api/app/%s/record/tracking/%s' % (
             pytest.swimlane_instance.host, pytest.appid, randomID)
 
-    @pytest.mark.xfail(reason="SPT-6030: Fail when the lookup value is empty or None")
     def test_record_get_by_empty_trackingId(helpers):
-        emptyID = ''
-        with pytest.raises(exceptions.HTTPError) as excinfo:
-            pytest.app.records.get(tracking_id=emptyID)
-        assert str(excinfo.value) == 'RecordNotFound:3002: Bad Request for url: %s/api/app/%s/record/tracking/%s' % (
-            pytest.swimlane_instance.host, pytest.appid, emptyID)
+        emptyTrackingID = ''
+        with pytest.raises(ValueError) as excinfo:
+            pytest.app.records.get(tracking_id=emptyTrackingID)
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
 
+    def test_record_get_by_null_trackingId(helpers):
+        noneTrackingID = None
+        with pytest.raises(ValueError) as excinfo:
+            pytest.app.records.get(tracking_id=noneTrackingID)
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
 
 class TestRecordAdaptorSearch:
     def test_record_search(helpers):

--- a/functional_tests/driver_tests/test_users_groups_adaptor.py
+++ b/functional_tests/driver_tests/test_users_groups_adaptor.py
@@ -70,13 +70,13 @@ class TestUserAdaptor:
         emptyID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(id=emptyID)
-        assert str(excinfo.value) == 'No id provided'
+        assert str(excinfo.value) == 'The value provided for the key "id" cannot be empty or None'
 
     def test_users_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(id=noneID)
-        assert str(excinfo.value) == 'No id provided'
+        assert str(excinfo.value) == 'The value provided for the key "id" cannot be empty or None'
 
     def test_users_get_by_display_name(helpers):
         swimUser = pytest.swimlane_instance.users.get(
@@ -95,14 +95,14 @@ class TestUserAdaptor:
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(display_name=emptyDisplayName)
         assert str(
-            excinfo.value) == 'No display_name provided'
+            excinfo.value) == 'The value provided for the key "display_name" cannot be empty or None'
 
     def test_users_get_by_null_display_name(helpers):
         noneDisplayName = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(display_name=noneDisplayName)
         assert str(
-            excinfo.value) == 'No display_name provided'
+            excinfo.value) == 'The value provided for the key "display_name" cannot be empty or None'
 
     def test_users_get_no_params(helpers):
         with pytest.raises(TypeError) as excinfo:
@@ -170,13 +170,13 @@ class TestGroupAdaptor:
         emptyID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(id=emptyID)
-        assert str(excinfo.value) == 'No id provided'
+        assert str(excinfo.value) == 'The value provided for the key "id" cannot be empty or None'
 
     def test_groups_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(id=noneID)
-        assert str(excinfo.value) == 'No id provided'
+        assert str(excinfo.value) == 'The value provided for the key "id" cannot be empty or None'
 
     def test_groups_get_by_name(helpers):
         swimGroup = pytest.swimlane_instance.groups.get(
@@ -195,14 +195,14 @@ class TestGroupAdaptor:
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(name=emptyName)
         assert str(
-            excinfo.value) == 'No name provided'
+            excinfo.value) == 'The value provided for the key "name" cannot be empty or None'
 
     def test_groups_get_by_null_name(helpers):
         noneName = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(name=noneName)
         assert str(
-            excinfo.value) == 'No name provided'
+            excinfo.value) == 'The value provided for the key "name" cannot be empty or None'
 
     def test_groups_get_no_params(helpers):
         with pytest.raises(TypeError) as excinfo:

--- a/functional_tests/driver_tests/test_users_groups_adaptor.py
+++ b/functional_tests/driver_tests/test_users_groups_adaptor.py
@@ -66,19 +66,17 @@ class TestUserAdaptor:
             pytest.swimlane_instance.users.get(id=randomID)
         assert str(excinfo.value) == 'Unable to find user with ID "%s"' % randomID
 
-    @pytest.mark.xfail(reason="SPT-6030: Testing for randomID as empty does not give formal response (attributeError)")
     def test_users_get_by_empty_id(helpers):
         emptyID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(id=emptyID)
-        assert str(excinfo.value) == 'Unable to find user with ID "%s"' % emptyID
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
 
-    @pytest.mark.xfail(reason="SPT-6030: Testing for display_Name as None givesValueError: Unable to find user with ID \"None\"")
     def test_users_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(id=noneID)
-        assert str(excinfo.value) == 'Unable to find user with ID "%s"' % noneID
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
 
     def test_users_get_by_display_name(helpers):
         swimUser = pytest.swimlane_instance.users.get(
@@ -92,19 +90,19 @@ class TestUserAdaptor:
         assert str(
             excinfo.value) == 'Unable to find user with display name "%s"' % randomDisplayName
 
-    @pytest.mark.xfail(reason="SPT-6030: Testing for display_Name as an empty string should fail")
     def test_users_get_by_empty_display_name(helpers):
         emptyDisplayName = ""
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(display_name=emptyDisplayName)
         assert str(
-            excinfo.value) == 'Unable to find user with display name "%s"' % emptyDisplayName
+            excinfo.value) == 'The lookup value can not be empty or None'
 
-    @pytest.mark.xfail(reason="SPT-6030: Testing for display_Name as None gives  TypeError: argument of type 'NoneType' is not iterable")
     def test_users_get_by_null_display_name(helpers):
-        randomDisplayName = None
-        # we should be catchiong an exception for the display_name being an invalid type.
-        pytest.swimlane_instance.users.get(display_name=randomDisplayName)
+        noneDisplayName = None
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.users.get(display_name=noneDisplayName)
+        assert str(
+            excinfo.value) == 'The lookup value can not be empty or None'
 
     def test_users_get_no_params(helpers):
         with pytest.raises(TypeError) as excinfo:
@@ -168,19 +166,17 @@ class TestGroupAdaptor:
             id=pytest.tempGroup['id'])
         assert swimGroup.for_json()["name"] == pytest.tempGroup['name']
 
-    @pytest.mark.xfail(reason="SPT-6030: Testing for randomID as empty does not give formal response (attributeError)")
     def test_groups_get_by_empty_id(helpers):
         emptyID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(id=emptyID)
-        assert str(excinfo.value) == 'Unable to find group with ID "%s"' % emptyID
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
 
-    @pytest.mark.xfail(reason="SPT-6030: Testing for ID as None givesValueError: Unable to find group with ID \"None\"")
     def test_groups_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(id=noneID)
-        assert str(excinfo.value) == 'Unable to find group with ID "%s"' % noneID
+        assert str(excinfo.value) == 'The lookup value can not be empty or None'
 
     def test_groups_get_by_name(helpers):
         swimGroup = pytest.swimlane_instance.groups.get(
@@ -194,21 +190,19 @@ class TestGroupAdaptor:
         assert str(
             excinfo.value) == 'Unable to find group with name "%s"' % randomName
 
-    @pytest.mark.xfail(reason="SPT-6030: Testing for name as empty string does error out")
     def test_groups_get_by_empty_name(helpers):
         emptyName = ""
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(name=emptyName)
         assert str(
-            excinfo.value) == 'Unable to find group with name "%s"' % emptyName
+            excinfo.value) == 'The lookup value can not be empty or None'
 
-    @pytest.mark.xfail(reason="SPT-6030: Testing for Name as None gives  TypeError: argument of type 'NoneType' is not iterable")
     def test_groups_get_by_null_name(helpers):
         noneName = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(name=noneName)
         assert str(
-            excinfo.value) == 'Unable to find group with name "%s"' % noneName
+            excinfo.value) == 'The lookup value can not be empty or None'
 
     def test_groups_get_no_params(helpers):
         with pytest.raises(TypeError) as excinfo:

--- a/functional_tests/driver_tests/test_users_groups_adaptor.py
+++ b/functional_tests/driver_tests/test_users_groups_adaptor.py
@@ -70,13 +70,13 @@ class TestUserAdaptor:
         emptyID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(id=emptyID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No id provided'
 
     def test_users_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(id=noneID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No id provided'
 
     def test_users_get_by_display_name(helpers):
         swimUser = pytest.swimlane_instance.users.get(
@@ -95,14 +95,14 @@ class TestUserAdaptor:
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(display_name=emptyDisplayName)
         assert str(
-            excinfo.value) == 'The lookup value can not be empty or None'
+            excinfo.value) == 'No display_name provided'
 
     def test_users_get_by_null_display_name(helpers):
         noneDisplayName = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.users.get(display_name=noneDisplayName)
         assert str(
-            excinfo.value) == 'The lookup value can not be empty or None'
+            excinfo.value) == 'No display_name provided'
 
     def test_users_get_no_params(helpers):
         with pytest.raises(TypeError) as excinfo:
@@ -170,13 +170,13 @@ class TestGroupAdaptor:
         emptyID = ''
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(id=emptyID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No id provided'
 
     def test_groups_get_by_null_id(helpers):
         noneID = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(id=noneID)
-        assert str(excinfo.value) == 'The lookup value can not be empty or None'
+        assert str(excinfo.value) == 'No id provided'
 
     def test_groups_get_by_name(helpers):
         swimGroup = pytest.swimlane_instance.groups.get(
@@ -195,14 +195,14 @@ class TestGroupAdaptor:
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(name=emptyName)
         assert str(
-            excinfo.value) == 'The lookup value can not be empty or None'
+            excinfo.value) == 'No name provided'
 
     def test_groups_get_by_null_name(helpers):
         noneName = None
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.groups.get(name=noneName)
         assert str(
-            excinfo.value) == 'The lookup value can not be empty or None'
+            excinfo.value) == 'No name provided'
 
     def test_groups_get_no_params(helpers):
         with pytest.raises(TypeError) as excinfo:

--- a/swimlane/core/adapters/app.py
+++ b/swimlane/core/adapters/app.py
@@ -26,8 +26,8 @@ class AppAdapter(SwimlaneResolver):
             ValueError: No matching app found on server
             ValueError: The lookup value is empty or None
         """
-        if value == '' or value == None:
-            raise ValueError('The lookup value can not be empty or None')
+        if not value:
+            raise ValueError('No {} provided'.format(key))
 
         if key == 'id':
             # Server returns 204 instead of 404 for a non-existent app id

--- a/swimlane/core/adapters/app.py
+++ b/swimlane/core/adapters/app.py
@@ -27,7 +27,7 @@ class AppAdapter(SwimlaneResolver):
             ValueError: The lookup value is empty or None
         """
         if not value:
-            raise ValueError('No {} provided'.format(key))
+            raise ValueError('The value provided for the key "{0}" cannot be empty or None'.format(key))
 
         if key == 'id':
             # Server returns 204 instead of 404 for a non-existent app id

--- a/swimlane/core/adapters/app.py
+++ b/swimlane/core/adapters/app.py
@@ -24,7 +24,11 @@ class AppAdapter(SwimlaneResolver):
         Raises:
             TypeError: No or multiple keyword arguments provided
             ValueError: No matching app found on server
+            ValueError: The lookup value is empty or None
         """
+        if value == '' or value == None:
+            raise ValueError('The lookup value can not be empty or None')
+
         if key == 'id':
             # Server returns 204 instead of 404 for a non-existent app id
             response = self._swimlane.request('get', 'app/{}'.format(value))

--- a/swimlane/core/adapters/record.py
+++ b/swimlane/core/adapters/record.py
@@ -31,7 +31,12 @@ class RecordAdapter(AppResolver):
 
         Raises:
             TypeError: No id argument provided
+            ValueError: The lookup value is empty or None
         """
+
+        if value == '' or value == None:
+            raise ValueError('The lookup value can not be empty or None')
+
         if key == 'id':
             response = self._swimlane.request('get', "app/{0}/record/{1}".format(self._app.id, value))
             return Record(self._app, response.json())

--- a/swimlane/core/adapters/record.py
+++ b/swimlane/core/adapters/record.py
@@ -34,8 +34,8 @@ class RecordAdapter(AppResolver):
             ValueError: The lookup value is empty or None
         """
 
-        if value == '' or value == None:
-            raise ValueError('The lookup value can not be empty or None')
+        if not value:
+            raise ValueError('No {} provided'.format(key))
 
         if key == 'id':
             response = self._swimlane.request('get', "app/{0}/record/{1}".format(self._app.id, value))

--- a/swimlane/core/adapters/record.py
+++ b/swimlane/core/adapters/record.py
@@ -35,7 +35,7 @@ class RecordAdapter(AppResolver):
         """
 
         if not value:
-            raise ValueError('No {} provided'.format(key))
+            raise ValueError('The value provided for the key "{0}" cannot be empty or None'.format(key))
 
         if key == 'id':
             response = self._swimlane.request('get', "app/{0}/record/{1}".format(self._app.id, value))

--- a/swimlane/core/adapters/usergroup.py
+++ b/swimlane/core/adapters/usergroup.py
@@ -65,8 +65,8 @@ class GroupAdapter(SwimlaneResolver):
         Returns:
             Group: Group instance matching provided inputs
         """
-        if value == '' or value == None:
-            raise ValueError('The lookup value can not be empty or None')
+        if not value:
+            raise ValueError('No {} provided'.format(key))
 
         if key == 'id':
             response = self._swimlane.request('get', 'groups/{}'.format(value))
@@ -144,8 +144,8 @@ class UserAdapter(SwimlaneResolver):
             ValueError: No matching user found based on provided inputs, or multiple Users with same display name
             ValueError: The lookup value is empty or None
         """
-        if value == '' or value == None:
-            raise ValueError('The lookup value can not be empty or None')
+        if not value:
+            raise ValueError('No {} provided'.format(arg))
 
         if arg == 'id':
             response = self._swimlane.request('get', 'user/{}'.format(value))

--- a/swimlane/core/adapters/usergroup.py
+++ b/swimlane/core/adapters/usergroup.py
@@ -66,7 +66,7 @@ class GroupAdapter(SwimlaneResolver):
             Group: Group instance matching provided inputs
         """
         if not value:
-            raise ValueError('No {} provided'.format(key))
+            raise ValueError('The value provided for the key "{0}" cannot be empty or None'.format(key))
 
         if key == 'id':
             response = self._swimlane.request('get', 'groups/{}'.format(value))
@@ -145,7 +145,7 @@ class UserAdapter(SwimlaneResolver):
             ValueError: The lookup value is empty or None
         """
         if not value:
-            raise ValueError('No {} provided'.format(arg))
+            raise ValueError('The value provided for the key "{0}" cannot be empty or None'.format(arg))
 
         if arg == 'id':
             response = self._swimlane.request('get', 'user/{}'.format(value))

--- a/swimlane/core/adapters/usergroup.py
+++ b/swimlane/core/adapters/usergroup.py
@@ -60,10 +60,14 @@ class GroupAdapter(SwimlaneResolver):
         Raises:
             TypeError: Unexpected or more than one keyword argument provided
             ValueError: No matching group found based on provided inputs
+            ValueError: The lookup value is empty or None
 
         Returns:
             Group: Group instance matching provided inputs
         """
+        if value == '' or value == None:
+            raise ValueError('The lookup value can not be empty or None')
+
         if key == 'id':
             response = self._swimlane.request('get', 'groups/{}'.format(value))
             return Group(self._swimlane, response.json())
@@ -138,7 +142,11 @@ class UserAdapter(SwimlaneResolver):
         Raises:
             TypeError: Unexpected or more than one keyword argument provided
             ValueError: No matching user found based on provided inputs, or multiple Users with same display name
+            ValueError: The lookup value is empty or None
         """
+        if value == '' or value == None:
+            raise ValueError('The lookup value can not be empty or None')
+
         if arg == 'id':
             response = self._swimlane.request('get', 'user/{}'.format(value))
 


### PR DESCRIPTION
- For the app GET by id and name call, check if lookup value is empty or None, if it is raises a ValueError and returns a specific response
- For the records GET by id and tracking_id call, check if lookup value is empty or None, if it is raises a ValueError and returns a specific response
- For the users GET by id and display_name call, check if lookup value is empty or None, if it is raises a ValueError and returns a specific response
- For the groups GET by id and name call, check if lookup value is empty or None, if it is raises a ValueError and returns a specific response
- Update and add tests to app, records, users and groups adapters