### PR TITLE
Load records with invalid selection field values

### DIFF
--- a/swimlane/core/fields/base/multiselect.py
+++ b/swimlane/core/fields/base/multiselect.py
@@ -12,6 +12,7 @@ class MultiSelectCursor(FieldCursor):
     def __init__(self, *args, **kwargs):
         super(MultiSelectCursor, self).__init__(*args, **kwargs)
 
+        self._elements = filter(lambda e: e is not None, self._elements)
         self._elements = SortedSet(self._elements)
 
     def select(self, element):
@@ -51,8 +52,7 @@ class MultiSelectField(CursorField):
             children = []
             if value:
                 for child in value:
-                    children.append(self.cast_to_swimlane(child))
-
+                        children.append(self.cast_to_swimlane(child))
                 return children
             return None
         return super(MultiSelectField, self).get_swimlane()

--- a/swimlane/core/fields/valueslist.py
+++ b/swimlane/core/fields/valueslist.py
@@ -39,14 +39,17 @@ class ValuesListField(MultiSelectField):
     def cast_to_python(self, value):
         """Store actual value as internal representation"""
         if value is not None:
-            value = value['value']
+            if value['value'] in self.selection_to_id_map:
+                return value['value']
 
-        return value
+        return None
 
     def cast_to_swimlane(self, value):
         """Rehydrate value back as full JSON representation"""
         if value is None:
             return value
+        if value not in self.selection_to_id_map:
+            return None
 
         return {
             '$type': 'Core.Models.Record.ValueSelection, Core',


### PR DESCRIPTION
Deleted selection field values can leave records in a state which the driver cannot load. For a single-select or a multi-select field, we cross-reference values with the field definition, and this caused an exception.

The scenario:
- Create an application with a multi-select field which has several options
- Create a record with multiple options selected
- Remove one selection option from the application
- Try to load the record

This change will allow the records to be loaded without out-of-date invalid values. Any valid selections in a multi-select field will still be present.