### PR TITLE
SPT-6195: Pydriver: add_comment with null or empty message should throw error

### DIFF
--- a/functional_tests/driver_tests/test_helpers_adaptor.py
+++ b/functional_tests/driver_tests/test_helpers_adaptor.py
@@ -76,45 +76,41 @@ class TestHelpersAddCommentAdaptor:
                 pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText, 123)
         assert str(excinfo.value) == "rich_text must be a boolean value."
 
-    @pytest.mark.xfail(reason="SPT-6196: Message Value is not checked for valid test.")
     def test_comment_empty(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = ''
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "message must not be an empty string value."
 
-    @pytest.mark.xfail(reason="SPT-6195: Message Value is not checked for valid test.")
     def test_comment_none(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = None
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "message must be a string value."
 
-    @pytest.mark.xfail(reason="SPT-6195: Message Value is not checked for valid test.")
     def test_comment_number(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = 123
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "message must be a string value."
 
-    @pytest.mark.xfail(reason="SPT-6195: Message Value is not checked for valid test.")
     def test_comment_object(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = {'Name': 'Fred'}
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "message must be a string value."
 
     def test_comment_missing(helpers):
         sourceRecord = pytest.app.records.create(
@@ -125,38 +121,35 @@ class TestHelpersAddCommentAdaptor:
         assert str(excinfo.value) == 'add_comment() {}'.format(
             pytest.helpers.py_ver_missing_param(5, 4, "message", "at least"))
 
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify that the commentFieldID should be a valid value")
     def test_comment_empty_fieldId(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
         commendFieldId = ''
-        pytest.swimlane_instance.helpers.add_comment(
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
             pytest.app.id, sourceRecord.id, commendFieldId, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        assert str(excinfo.value) == "field_id must not be an empty string value."
 
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify that the recordID should be a valid value")
     def test_comment_empty_recordId(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
         recordId = ''
-        pytest.swimlane_instance.helpers.add_comment(
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
             pytest.app.id, recordId, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        assert str(excinfo.value) == "record_id must not be an empty string value."
 
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify that the appID should be a valid value")
     def test_comment_empty_appId(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
         appId = ''
-        pytest.swimlane_instance.helpers.add_comment(
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
             appId, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert len(editedRecord['Comments']) == 0
+        assert str(excinfo.value) == "app_id must not be an empty string value."
 
     def test_comment_missmatch_appid(helpers):
         sourceRecord = pytest.app.records.create(
@@ -188,25 +181,23 @@ class TestHelpersAddCommentAdaptor:
         editedRecord = pytest.app.records.get(id=sourceRecord.id)
         assert len(editedRecord['Comments']) == 0
 
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify the IDs are valid input.")
     def test_comment_app_object(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert len(editedRecord['Comments']) == 0
-
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify the IDs are valid input.")
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "app_id must be a string value."
+    
     def test_comment_record_object(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert len(editedRecord['Comments']) == 0
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "record_id must be a string value."
 
 
 class TestHelpersAddRefernceAdaptor:

--- a/swimlane/core/adapters/helper.py
+++ b/swimlane/core/adapters/helper.py
@@ -2,6 +2,7 @@ import pendulum
 
 from swimlane.core.resolver import SwimlaneResolver
 from swimlane.utils.version import requires_swimlane_version
+from swimlane.utils.str_validator import validate_str
 
 
 class HelperAdapter(SwimlaneResolver):
@@ -43,15 +44,10 @@ class HelperAdapter(SwimlaneResolver):
             message (str): New comment message body
             rich_text (bool): Declare the message as being rich text, default is False
         """
-        self.validate_str(app_id, 'app_id')
-        self.validate_str(record_id, 'record_id')
-        self.validate_str(field_id, 'field_id')
-        self.validate_str(message, 'message')
-        
-        self.validate_str_emptiness(app_id, 'app_id')
-        self.validate_str_emptiness(record_id, 'record_id')
-        self.validate_str_emptiness(field_id, 'field_id')
-        self.validate_str_emptiness(message, 'message')
+        validate_str(app_id, 'app_id')
+        validate_str(record_id, 'record_id')
+        validate_str(field_id, 'field_id')
+        validate_str(message, 'message')
         
         if not isinstance(rich_text, bool):
             raise ValueError("rich_text must be a boolean value.")
@@ -82,11 +78,3 @@ class HelperAdapter(SwimlaneResolver):
         """
 
         return self._swimlane.request('get', "logging/job/{0}".format(job_id)).json()
-
-    def validate_str(self, value, key):
-        if not isinstance(value, str):
-            raise ValueError('{} must be a string value.'.format(key))
-
-    def validate_str_emptiness(self, value, key):
-        if value.strip() == '':
-            raise ValueError('{} must not be an empty string value.'.format(key))

--- a/swimlane/core/adapters/helper.py
+++ b/swimlane/core/adapters/helper.py
@@ -43,6 +43,16 @@ class HelperAdapter(SwimlaneResolver):
             message (str): New comment message body
             rich_text (bool): Declare the message as being rich text, default is False
         """
+        self.validate_str(app_id, 'app_id')
+        self.validate_str(record_id, 'record_id')
+        self.validate_str(field_id, 'field_id')
+        self.validate_str(message, 'message')
+        
+        self.validate_str_emptiness(app_id, 'app_id')
+        self.validate_str_emptiness(record_id, 'record_id')
+        self.validate_str_emptiness(field_id, 'field_id')
+        self.validate_str_emptiness(message, 'message')
+        
         if not isinstance(rich_text, bool):
             raise ValueError("rich_text must be a boolean value.")
 
@@ -72,3 +82,11 @@ class HelperAdapter(SwimlaneResolver):
         """
 
         return self._swimlane.request('get', "logging/job/{0}".format(job_id)).json()
+
+    def validate_str(self, value, key):
+        if not isinstance(value, str):
+            raise ValueError('{} must be a string value.'.format(key))
+
+    def validate_str_emptiness(self, value, key):
+        if value.strip() == '':
+            raise ValueError('{} must not be an empty string value.'.format(key))

--- a/swimlane/utils/str_validator.py
+++ b/swimlane/utils/str_validator.py
@@ -1,0 +1,5 @@
+def validate_str(value, key):
+  if not isinstance(value, str):
+    raise ValueError('{} must be a string value.'.format(key))
+  if value.strip() == '':
+    raise ValueError('{} must not be an empty string value.'.format(key))


### PR DESCRIPTION
# Devex Change Request

## Change Comments

I updated the library to validate all the arguments received in add_comment.

## Solution description

I validate all the arguments received in add_comment, to avoid empty strings or any other type different a string.

Evidences:
_**Current:**_
<img width="1603" alt="Screen Shot 2022-12-21 at 9 01 18 PM" src="https://user-images.githubusercontent.com/100230626/209046190-b45f2173-0543-49b1-99c9-9fd42c67e476.png">

<img width="1603" alt="Screen Shot 2022-12-21 at 9 02 49 PM" src="https://user-images.githubusercontent.com/100230626/209046364-0a439f65-245e-4b83-aaad-d6e8fc3fc9e1.png">

<img width="1603" alt="Screen Shot 2022-12-21 at 9 03 36 PM" src="https://user-images.githubusercontent.com/100230626/209046453-eed6788c-0a8f-43ef-8139-7e5a44d91151.png">

![Screen Shot 2022-12-21 at 9 00 18 PM](https://user-images.githubusercontent.com/100230626/209046058-4e2cf930-d648-484e-95c3-e00422ead1d0.png)

_**Fixed:**_
<img width="1721" alt="Screen Shot 2022-12-21 at 8 28 35 PM" src="https://user-images.githubusercontent.com/100230626/209041977-740c5a47-0291-4217-bd42-8f256d3a406c.png">

<img width="1721" alt="Screen Shot 2022-12-21 at 8 29 03 PM" src="https://user-images.githubusercontent.com/100230626/209042034-3d59b168-fe8f-460a-aab9-36fc3a10fcd2.png">

<img width="1721" alt="Screen Shot 2022-12-21 at 8 29 59 PM" src="https://user-images.githubusercontent.com/100230626/209042165-8112dbd2-0df1-4473-8f9e-8fc9faa0c0f3.png">

![Screen Shot 2022-12-21 at 8 46 14 PM](https://user-images.githubusercontent.com/100230626/209044334-3e13aae9-a77a-483f-a0bd-932c6f1da6c7.png)

## Checklist

<!-- Strike out any steps that do not apply -->

_**PR is ready for code review and approval when each box is checked.**_

_All steps are required, when applicable. ~Strikeout~ formatting indicates a step is not applicable to this change set._

- [x] Ticket referenced in PR title (ex. _SPT-XXX: Short summary of change_)