### PR TITLE
SPT-6107: add navigation scrolling

### DIFF
--- a/docs/_static/css/navigation.css
+++ b/docs/_static/css/navigation.css
@@ -1,0 +1,14 @@
+
+body {
+  height: 100%;
+}
+
+.sphinxsidebar {
+  height: 100%;
+  overflow-y: hidden;
+}
+
+.sphinxsidebarwrapper {
+  height: calc(100% - 30px - 18px - 18px);
+  overflow-y: scroll;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,6 +129,10 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_css_files = [
+    'css/navigation.css',
+]
+
 html_logo = 'logo.png'
 html_favicon = 'favicon.ico'
 


### PR DESCRIPTION
ISSUE:
Unable to scroll down on the left navigation menu for page https://swimlane-python-driver.readthedocs.io/en/stable/examples/resources.html

Added custom CSS page to add scrollability to Navigation