### PR TITLE
SPT:6233 Pydriver: check_bulk_job_status with invalid Ids should throw error

### DIFF
--- a/functional_tests/driver_tests/test_helpers_adaptor.py
+++ b/functional_tests/driver_tests/test_helpers_adaptor.py
@@ -322,7 +322,7 @@ class TestHelpersBulkJobStatusAdaptor:
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.helpers.check_bulk_job_status(
                 bulkJobID)
-            assert str(excinfo.value) == "job_id must not be an empty string value."
+        assert str(excinfo.value) == "job_id must not be an empty string value."
 
     def test_check_bulk_status_no_params(helpers):
         with pytest.raises(TypeError) as excinfo:

--- a/functional_tests/driver_tests/test_helpers_adaptor.py
+++ b/functional_tests/driver_tests/test_helpers_adaptor.py
@@ -309,19 +309,20 @@ class TestHelpersBulkJobStatusAdaptor:
             bulkJobID)
         assert len(loggingStuff) > 0
 
-    @pytest.mark.xfail(reason="SPT-6233: Should verify the bulkJobID is a non-empty string.")
     def test_check_bulk_status_null_id(helpers):
         bulkJobID = None
-        loggingStuff = pytest.swimlane_instance.helpers.check_bulk_job_status(
-            bulkJobID)
-        assert len(loggingStuff) == 0
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.check_bulk_job_status(
+                bulkJobID)
+            assert str(excinfo.value) == "job_id must be a string value."
 
     @pytest.mark.xfail(reason="SPT-6233: Should verify the bulkJobID is a non-empty string.")
     def test_check_bulk_status_empty_id(helpers):
         bulkJobID = ''
-        loggingStuff = pytest.swimlane_instance.helpers.check_bulk_job_status(
-            bulkJobID)
-        assert len(loggingStuff) == 0
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.check_bulk_job_status(
+                bulkJobID)
+            assert str(excinfo.value) == "job_id must not be an empty string value."
 
     def test_check_bulk_status_no_params(helpers):
         with pytest.raises(TypeError) as excinfo:
@@ -335,16 +336,17 @@ class TestHelpersBulkJobStatusAdaptor:
             bulkJobID)
         assert len(loggingStuff) == 0
 
-    @pytest.mark.xfail(reason="SPT-6233: Should verify the bulkJobID is a non-empty string.")
+    
     def test_check_bulk_status_numeric_id(helpers):
         bulkJobID = 1.5
-        loggingStuff = pytest.swimlane_instance.helpers.check_bulk_job_status(
-            bulkJobID)
-        assert len(loggingStuff) == 0
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.check_bulk_job_status(
+                bulkJobID)
+            assert str(excinfo.value) == "job_id must be a string value."
 
-    @pytest.mark.xfail(reason="SPT-6233: Should verify the bulkJobID is a non-empty string.")
     def test_check_bulk_status_object_id(helpers):
         bulkJobID = {'name': 'bob'}
-        loggingStuff = pytest.swimlane_instance.helpers.check_bulk_job_status(
-            bulkJobID)
-        assert len(loggingStuff) == 0
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.check_bulk_job_status(
+                bulkJobID)
+            assert str(excinfo.value) == "job_id must be a string value."

--- a/functional_tests/driver_tests/test_helpers_adaptor.py
+++ b/functional_tests/driver_tests/test_helpers_adaptor.py
@@ -314,7 +314,7 @@ class TestHelpersBulkJobStatusAdaptor:
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.helpers.check_bulk_job_status(
                 bulkJobID)
-            assert str(excinfo.value) == "job_id must be a string value."
+        assert str(excinfo.value) == "job_id must be a string value."
 
     @pytest.mark.xfail(reason="SPT-6233: Should verify the bulkJobID is a non-empty string.")
     def test_check_bulk_status_empty_id(helpers):
@@ -342,11 +342,11 @@ class TestHelpersBulkJobStatusAdaptor:
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.helpers.check_bulk_job_status(
                 bulkJobID)
-            assert str(excinfo.value) == "job_id must be a string value."
+        assert str(excinfo.value) == "job_id must be a string value."
 
     def test_check_bulk_status_object_id(helpers):
         bulkJobID = {'name': 'bob'}
         with pytest.raises(ValueError) as excinfo:
             pytest.swimlane_instance.helpers.check_bulk_job_status(
                 bulkJobID)
-            assert str(excinfo.value) == "job_id must be a string value."
+        assert str(excinfo.value) == "job_id must be a string value."

--- a/functional_tests/driver_tests/test_helpers_adaptor.py
+++ b/functional_tests/driver_tests/test_helpers_adaptor.py
@@ -76,45 +76,41 @@ class TestHelpersAddCommentAdaptor:
                 pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText, 123)
         assert str(excinfo.value) == "rich_text must be a boolean value."
 
-    @pytest.mark.xfail(reason="SPT-6196: Message Value is not checked for valid test.")
     def test_comment_empty(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = ''
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "message must not be an empty string value."
 
-    @pytest.mark.xfail(reason="SPT-6195: Message Value is not checked for valid test.")
     def test_comment_none(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = None
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "message must be a string value."
 
-    @pytest.mark.xfail(reason="SPT-6195: Message Value is not checked for valid test.")
     def test_comment_number(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = 123
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "message must be a string value."
 
-    @pytest.mark.xfail(reason="SPT-6195: Message Value is not checked for valid test.")
     def test_comment_object(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = {'Name': 'Fred'}
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "message must be a string value."
 
     def test_comment_missing(helpers):
         sourceRecord = pytest.app.records.create(
@@ -125,38 +121,35 @@ class TestHelpersAddCommentAdaptor:
         assert str(excinfo.value) == 'add_comment() {}'.format(
             pytest.helpers.py_ver_missing_param(5, 4, "message", "at least"))
 
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify that the commentFieldID should be a valid value")
     def test_comment_empty_fieldId(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
         commendFieldId = ''
-        pytest.swimlane_instance.helpers.add_comment(
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
             pytest.app.id, sourceRecord.id, commendFieldId, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        assert str(excinfo.value) == "field_id must not be an empty string value."
 
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify that the recordID should be a valid value")
     def test_comment_empty_recordId(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
         recordId = ''
-        pytest.swimlane_instance.helpers.add_comment(
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
             pytest.app.id, recordId, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert editedRecord['Comments'][-1].message == commentText
+        assert str(excinfo.value) == "record_id must not be an empty string value."
 
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify that the appID should be a valid value")
     def test_comment_empty_appId(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
         appId = ''
-        pytest.swimlane_instance.helpers.add_comment(
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
             appId, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert len(editedRecord['Comments']) == 0
+        assert str(excinfo.value) == "app_id must not be an empty string value."
 
     def test_comment_missmatch_appid(helpers):
         sourceRecord = pytest.app.records.create(
@@ -188,25 +181,23 @@ class TestHelpersAddCommentAdaptor:
         editedRecord = pytest.app.records.get(id=sourceRecord.id)
         assert len(editedRecord['Comments']) == 0
 
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify the IDs are valid input.")
     def test_comment_app_object(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app, sourceRecord.id, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert len(editedRecord['Comments']) == 0
-
-    @pytest.mark.xfail(reason="SPT-6196: Pydriver should verify the IDs are valid input.")
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app, sourceRecord.id, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "app_id must be a string value."
+    
     def test_comment_record_object(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
         commentText = pytest.fake.sentence()
-        pytest.swimlane_instance.helpers.add_comment(
-            pytest.app.id, sourceRecord, pytest.CommentFieldID, commentText)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert len(editedRecord['Comments']) == 0
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_comment(
+                pytest.app.id, sourceRecord, pytest.CommentFieldID, commentText)
+        assert str(excinfo.value) == "record_id must be a string value."
 
 
 class TestHelpersAddRefernceAdaptor:

--- a/swimlane/core/adapters/helper.py
+++ b/swimlane/core/adapters/helper.py
@@ -2,6 +2,7 @@ import pendulum
 
 from swimlane.core.resolver import SwimlaneResolver
 from swimlane.utils.version import requires_swimlane_version
+from swimlane.utils.str_validator import validate_str
 
 
 class HelperAdapter(SwimlaneResolver):
@@ -43,15 +44,10 @@ class HelperAdapter(SwimlaneResolver):
             message (str): New comment message body
             rich_text (bool): Declare the message as being rich text, default is False
         """
-        self.validate_str(app_id, 'app_id')
-        self.validate_str(record_id, 'record_id')
-        self.validate_str(field_id, 'field_id')
-        self.validate_str(message, 'message')
-        
-        self.validate_str_emptiness(app_id, 'app_id')
-        self.validate_str_emptiness(record_id, 'record_id')
-        self.validate_str_emptiness(field_id, 'field_id')
-        self.validate_str_emptiness(message, 'message')
+        validate_str(app_id, 'app_id')
+        validate_str(record_id, 'record_id')
+        validate_str(field_id, 'field_id')
+        validate_str(message, 'message')
         
         if not isinstance(rich_text, bool):
             raise ValueError("rich_text must be a boolean value.")
@@ -82,11 +78,3 @@ class HelperAdapter(SwimlaneResolver):
         """
 
         return self._swimlane.request('get', "logging/job/{0}".format(job_id)).json()
-
-    def validate_str(self, value, key):
-        if not isinstance(value, str):
-            raise ValueError('{} must be a string value.'.format(key))
-
-    def validate_str_emptiness(self, value, key):
-        if value.strip() == '':
-            raise ValueError('{} must not be an empty string value.'.format(key))

--- a/swimlane/core/adapters/helper.py
+++ b/swimlane/core/adapters/helper.py
@@ -76,5 +76,7 @@ class HelperAdapter(SwimlaneResolver):
             :class:`list` of :class:`dict`: List of dictionaries containing job history
 
         """
+        
+        validate_str(job_id, 'job_id')
 
         return self._swimlane.request('get', "logging/job/{0}".format(job_id)).json()

--- a/swimlane/core/adapters/helper.py
+++ b/swimlane/core/adapters/helper.py
@@ -43,6 +43,16 @@ class HelperAdapter(SwimlaneResolver):
             message (str): New comment message body
             rich_text (bool): Declare the message as being rich text, default is False
         """
+        self.validate_str(app_id, 'app_id')
+        self.validate_str(record_id, 'record_id')
+        self.validate_str(field_id, 'field_id')
+        self.validate_str(message, 'message')
+        
+        self.validate_str_emptiness(app_id, 'app_id')
+        self.validate_str_emptiness(record_id, 'record_id')
+        self.validate_str_emptiness(field_id, 'field_id')
+        self.validate_str_emptiness(message, 'message')
+        
         if not isinstance(rich_text, bool):
             raise ValueError("rich_text must be a boolean value.")
 
@@ -72,3 +82,11 @@ class HelperAdapter(SwimlaneResolver):
         """
 
         return self._swimlane.request('get', "logging/job/{0}".format(job_id)).json()
+
+    def validate_str(self, value, key):
+        if not isinstance(value, str):
+            raise ValueError('{} must be a string value.'.format(key))
+
+    def validate_str_emptiness(self, value, key):
+        if value.strip() == '':
+            raise ValueError('{} must not be an empty string value.'.format(key))

--- a/swimlane/utils/str_validator.py
+++ b/swimlane/utils/str_validator.py
@@ -1,0 +1,5 @@
+def validate_str(value, key):
+  if not isinstance(value, str):
+    raise ValueError('{} must be a string value.'.format(key))
+  if value.strip() == '':
+    raise ValueError('{} must not be an empty string value.'.format(key))


### PR DESCRIPTION
# Devex Change Request

## Change Comments

I updated the library to validate the argument received in check_bulk_job_status.

## Solution description

I validate the job_id, to avoid empty strings or any other type different a string.

Evidences:
_**Current:**_
![Screen Shot 2022-12-30 at 8 26 21 AM](https://user-images.githubusercontent.com/100230626/210081343-c4913fe9-1ab2-4a78-b944-51f3f7d9911a.png)

![Screen Shot 2022-12-30 at 8 26 47 AM](https://user-images.githubusercontent.com/100230626/210081358-66025926-04f8-4f0a-a5d9-4a5069114f91.png)

![Screen Shot 2022-12-30 at 8 27 26 AM](https://user-images.githubusercontent.com/100230626/210081377-cea18eb2-bfb8-4bfe-b269-39f79ff5d200.png)

![Screen Shot 2022-12-30 at 8 28 13 AM](https://user-images.githubusercontent.com/100230626/210081385-5ff3e5e7-4663-46f9-ac4e-db56b3cea02d.png)

![Screen Shot 2022-12-21 at 9 00 18 PM](https://user-images.githubusercontent.com/100230626/209046058-4e2cf930-d648-484e-95c3-e00422ead1d0.png)

_**Fixed:**_
![Screen Shot 2022-12-30 at 8 28 38 AM](https://user-images.githubusercontent.com/100230626/210081454-eae530bd-1e67-4ff1-abbc-cde96db4d54f.png)

![Screen Shot 2022-12-30 at 8 29 04 AM](https://user-images.githubusercontent.com/100230626/210081463-78b01abc-6cb7-41cd-a92f-c8c128d8b5b7.png)

![Screen Shot 2022-12-30 at 8 29 59 AM](https://user-images.githubusercontent.com/100230626/210081477-23e155d6-79c2-4b21-be44-bc34a4e3a853.png)

![Screen Shot 2022-12-30 at 8 30 33 AM](https://user-images.githubusercontent.com/100230626/210081488-90e1a9fb-94bf-418e-a260-fd5c9853f4fb.png)


![Screen Shot 2022-12-21 at 9 19 28 PM](https://user-images.githubusercontent.com/100230626/209048310-692d21ed-53cd-409e-bef1-cc0391c03a91.png)

## Checklist

<!-- Strike out any steps that do not apply -->

_**PR is ready for code review and approval when each box is checked.**_

_All steps are required, when applicable. ~Strikeout~ formatting indicates a step is not applicable to this change set._

- [x] Ticket referenced in PR title (ex. _SPT-XXX: Short summary of change_)