### PR TITLE
SPT-6241: add_record_references should validate the references list contains valid data

### DIFF
--- a/functional_tests/driver_tests/test_helpers_adaptor.py
+++ b/functional_tests/driver_tests/test_helpers_adaptor.py
@@ -221,31 +221,52 @@ class TestHelpersAddRefernceAdaptor:
         assert editedRecord['Reference'][-1] == pytest.targetRecord
         assert len(editedRecord['Reference']) == currentRefCount + 1
 
-    @pytest.mark.xfail(reason="SPT-6241: Verify record to add to ref field.")
     def test_addReference_empty_list(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
-        currentRefCount = len(pytest.app.records.get(
-            id=sourceRecord.id)['Reference'])
         recordsToAddRef = []
-        pytest.swimlane_instance.helpers.add_record_references(
-            pytest.app.id, sourceRecord.id, pytest.refFieldID, recordsToAddRef)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert len(editedRecord['Reference']) == currentRefCount
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_record_references(
+                pytest.app.id, sourceRecord.id, pytest.refFieldID, recordsToAddRef)
+        assert str(excinfo.value) == "target_record_ids must be a non-empty list value"
 
-    @pytest.mark.xfail(reason="SPT-6241, SPT-6242: Verify record to add to ref field.  Actually added another reference.")
     def test_addReference_list_empty_str(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})
-        currentRefCount = len(pytest.app.records.get(
-            id=sourceRecord.id)['Reference'])
         recordsToAddRef = ['']
-        pytest.swimlane_instance.helpers.add_record_references(
-            pytest.app.id, sourceRecord.id, pytest.refFieldID, recordsToAddRef)
-        editedRecord = pytest.app.records.get(id=sourceRecord.id)
-        assert len(editedRecord['Reference']) == currentRefCount
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_record_references(
+                pytest.app.id, sourceRecord.id, pytest.refFieldID, recordsToAddRef)
+        assert str(excinfo.value) == "target_record_ids must contain non-empty string values"
+    
+    def test_addReference_list_int(helpers):
+        sourceRecord = pytest.app.records.create(
+            **{'Text': pytest.fake.sentence()})
+        recordsToAddRef = [123]
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_record_references(
+                pytest.app.id, sourceRecord.id, pytest.refFieldID, recordsToAddRef)
+        assert str(excinfo.value) == "target_record_ids must contain non-empty string values"
 
-    @pytest.mark.xfail(reason="SPT-6241, SPT-6242: Verify record to add to ref field. Bombs out on the assert line.")
+    def test_addReference_list_dict(helpers):
+        sourceRecord = pytest.app.records.create(
+            **{'Text': pytest.fake.sentence()})
+        recordsToAddRef = [{'test':'dict'}]
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_record_references(
+                pytest.app.id, sourceRecord.id, pytest.refFieldID, recordsToAddRef)
+        assert str(excinfo.value) == "target_record_ids must contain non-empty string values"
+    
+    def test_addReference_not_list(helpers):
+        sourceRecord = pytest.app.records.create(
+            **{'Text': pytest.fake.sentence()})
+        recordsToAddRef = 123
+        with pytest.raises(ValueError) as excinfo:
+            pytest.swimlane_instance.helpers.add_record_references(
+                pytest.app.id, sourceRecord.id, pytest.refFieldID, recordsToAddRef)
+        assert str(excinfo.value) == "target_record_ids must be a non-empty list value"
+
+    @pytest.mark.xfail(reason="SPT-6242: Verify record to add to ref field. Bombs out on the assert line.")
     def test_addReference_record_from_wrong_app(helpers):
         sourceRecord = pytest.app.records.create(
             **{'Text': pytest.fake.sentence()})

--- a/swimlane/core/adapters/helper.py
+++ b/swimlane/core/adapters/helper.py
@@ -2,6 +2,7 @@ import pendulum
 
 from swimlane.core.resolver import SwimlaneResolver
 from swimlane.utils.version import requires_swimlane_version
+from swimlane.utils.list_validator import validate_str_list
 
 
 class HelperAdapter(SwimlaneResolver):
@@ -20,6 +21,7 @@ class HelperAdapter(SwimlaneResolver):
             field_id (str): Full field ID to target reference field on parent Record string
             target_record_ids (List(str)): List of full target reference Record ID strings
         """
+        validate_str_list(target_record_ids, "target_record_ids")
 
         self._swimlane.request(
             'post',

--- a/swimlane/utils/list_validator.py
+++ b/swimlane/utils/list_validator.py
@@ -1,0 +1,7 @@
+def validate_str_list(value, key):
+    if not value or not isinstance(value, list):
+        raise ValueError('{} must be a non-empty list value'.format(key))
+    
+    for i in value:
+        if not isinstance(i, str) or i.strip() == '':
+            raise ValueError('{} must contain non-empty string values'.format(key))


### PR DESCRIPTION
- Added check in `add_record_references` to validate that the references list `target_record_ids` contains valid data. Raises a ValueError if validation fails and returns a specific response.
- Update and added tests to `HelperAdapter`.