### PR TITLE
SPT-6305: report.filter(...) should verify field name value

### DIFF
--- a/functional_tests/driver_tests/test_app_reporting_adaptor.py
+++ b/functional_tests/driver_tests/test_app_reporting_adaptor.py
@@ -162,29 +162,37 @@ class TestReportFilteringAdaptor:
         report.filter('Numeric', 'equals', 'Hello')
         assert len(report) == 0
 
-    @pytest.mark.xfail(reason="SPT-6305: Pydriver should verify that the filedName should be a valid value")
-    def test_reporting_invalid_field_name_type(helpers):
+    def test_reporting_invalid_field_name_type_None(helpers):
         report = pytest.app.reports.build(
             'report-%s' % pytest.fake.word(), limit=0)
         fieldName = None
-        report.filter(fieldName, 'equals', 'Hello')
-        assert len(report) == 0
+        with pytest.raises(ValueError) as excinfo:
+            report.filter(fieldName, 'equals', 'Hello')
+        assert str(excinfo.value) == "field_name is of an invalid format, expected non-empty string"
 
-    @pytest.mark.xfail(reason="SPT-6305: Pydriver should verify that the filedName should be a valid value")
     def test_reporting_invalid_field_name_type_number(helpers):
         report = pytest.app.reports.build(
             'report-%s' % pytest.fake.word(), limit=0)
         fieldName = 1234
-        report.filter(fieldName, 'equals', 'Hello')
-        assert len(report) == 0
+        with pytest.raises(ValueError) as excinfo:
+            report.filter(fieldName, 'equals', 'Hello')
+        assert str(excinfo.value) == "field_name is of an invalid format, expected non-empty string"
 
-    @pytest.mark.xfail(reason="SPT-6305: Pydriver should verify that the filedName should be a valid value")
     def test_reporting_invalid_field_name_type_object(helpers):
         report = pytest.app.reports.build(
             'report-%s' % pytest.fake.word(), limit=0)
         fieldName = {"Name": "Text"}
-        report.filter(fieldName, 'equals', 'Hello')
-        assert len(report) == 0
+        with pytest.raises(ValueError) as excinfo:
+            report.filter(fieldName, 'equals', 'Hello')
+        assert str(excinfo.value) == "field_name is of an invalid format, expected non-empty string"
+    
+    def test_reporting_invalid_field_name_empty(helpers):
+        report = pytest.app.reports.build(
+            'report-%s' % pytest.fake.word(), limit=0)
+        fieldName = ''
+        with pytest.raises(ValueError) as excinfo:
+            report.filter(fieldName, 'equals', 'Hello')
+        assert str(excinfo.value) == "field_name is of an invalid format, expected non-empty string"
 
     def test_reporting_missing_params(helpers):
         report = pytest.app.reports.build(

--- a/swimlane/core/resources/report.py
+++ b/swimlane/core/resources/report.py
@@ -151,6 +151,9 @@ class Report(APIResource, PaginatedCursor):
             self._raw['columns'].append(self._app.tracking_id)
 
     def _get_stub_field(self, field_name):
+        if not field_name or not isinstance(field_name, str):
+            raise ValueError('field_name is of an invalid format, expected non-empty string')
+
         # Use temp Record instance for target app to translate values into expected API format
         record_stub = record_factory(self._app)
         return record_stub.get_field(field_name)


### PR DESCRIPTION
- Added check in `_get_stub_field` to validate that `field_name` is of a valid format. Raises a ValueError if validation fails and returns a specific response.
- Updated and added tests to `test_app_reporting_adaptor`.