### PR TITLE
fix(SC-5540 SPT-6196): handling not iterable values on multiselect fields

### DIFF
--- a/swimlane/core/fields/base/multiselect.py
+++ b/swimlane/core/fields/base/multiselect.py
@@ -67,7 +67,15 @@ class MultiSelectField(CursorField):
             value = value or []
             elements = []
 
-            if not isinstance(value, (list, MultiSelectCursor, SortedSet)):
+            if not isinstance(
+                value,
+                (
+                    list,
+                    MultiSelectCursor,
+                    SortedSet,
+                    dict,
+                ),
+            ):
                 value = [value]
 
             for element in value:

--- a/swimlane/core/fields/base/multiselect.py
+++ b/swimlane/core/fields/base/multiselect.py
@@ -1,5 +1,7 @@
 from sortedcontainers import SortedSet
 
+from swimlane.core.resources.usergroup import User
+
 from .cursor import CursorField, FieldCursor
 
 
@@ -73,7 +75,7 @@ class MultiSelectField(CursorField):
                     list,
                     MultiSelectCursor,
                     SortedSet,
-                    dict,
+                    User,
                 ),
             ):
                 value = [value]

--- a/swimlane/core/fields/base/multiselect.py
+++ b/swimlane/core/fields/base/multiselect.py
@@ -5,7 +5,7 @@ from .cursor import CursorField, FieldCursor
 
 class MultiSelectCursor(FieldCursor):
     """Cursor allowing setting and unsetting values on a MultiSelectField
-    
+
     Respects parent field's validation
     """
 
@@ -16,7 +16,7 @@ class MultiSelectCursor(FieldCursor):
 
     def select(self, element):
         """Add an element to the set of selected elements
-        
+
         Proxy to internal set.add and sync field
         """
         self._field.validate_value(element)
@@ -25,7 +25,7 @@ class MultiSelectCursor(FieldCursor):
 
     def deselect(self, element):
         """Remove an element from the set of selected elements
-        
+
         Proxy to internal set.remove and sync field
         """
         self._elements.remove(element)
@@ -66,6 +66,9 @@ class MultiSelectField(CursorField):
         if self.multiselect:
             value = value or []
             elements = []
+
+            if not isinstance(value, (list, MultiSelectCursor, SortedSet)):
+                value = [value]
 
             for element in value:
                 self.validate_value(element)

--- a/swimlane/core/fields/usergroup.py
+++ b/swimlane/core/fields/usergroup.py
@@ -125,6 +125,9 @@ class UserGroupField(MultiSelectField):
     def cast_to_swimlane(self, value):
         """Dump UserGroup back to JSON representation"""
         if value is not None:
+            if not isinstance(value, UserGroup):
+                    raise TypeError(
+                        'Expected UserGroup, received `{}` instead'.format(value))
             value = value.as_usergroup_selection()
 
         return value

--- a/tests/fields/test_valueslist.py
+++ b/tests/fields/test_valueslist.py
@@ -68,14 +68,11 @@ def test_values_list_multi_select_field(mock_record):
     mock_record['Values List'] = vl_original_values
     assert len(mock_record['Values List']) == 2
 
-    # Attempt to directly set to a non-iterable value
+def test_set_not_iterable_value(mock_record):
     try:
         mock_record['Values List'] = 'Option 1'
-    except ValueError:
-        pass
-    else:
-        raise RuntimeError
-
+    except Exception as E:
+        raise E
 
 def test_cursor_repr(mock_record):
     assert repr(mock_record['Values List']) == '<MultiSelectCursor: <Record: RA-7>["Values List"] (2)>'

--- a/tests/fields/test_valueslist.py
+++ b/tests/fields/test_valueslist.py
@@ -69,10 +69,8 @@ def test_values_list_multi_select_field(mock_record):
     assert len(mock_record['Values List']) == 2
 
 def test_set_not_iterable_value(mock_record):
-    try:
-        mock_record['Values List'] = 'Option 1'
-    except Exception as E:
-        raise E
+    mock_record["Values List"] = "Option 1"
+
 
 def test_cursor_repr(mock_record):
     assert repr(mock_record['Values List']) == '<MultiSelectCursor: <Record: RA-7>["Values List"] (2)>'

--- a/tests/fields/test_valueslist.py
+++ b/tests/fields/test_valueslist.py
@@ -69,7 +69,12 @@ def test_values_list_multi_select_field(mock_record):
     assert len(mock_record['Values List']) == 2
 
 def test_set_not_iterable_value(mock_record):
-    mock_record["Values List"] = "Option 1"
+    # this can be done in a single line,
+    # I'm just being explicit here
+    try:
+        mock_record["Values List"] = "Option 1"
+    except Exception:
+        pytest.fail(Exception)
 
 
 def test_cursor_repr(mock_record):

--- a/tests/fields/test_valueslist.py
+++ b/tests/fields/test_valueslist.py
@@ -74,7 +74,7 @@ def test_set_not_iterable_value(mock_record):
     try:
         mock_record["Values List"] = "Option 1"
     except Exception:
-        pytest.fail(Exception)
+        raise RuntimeError
 
 
 def test_cursor_repr(mock_record):


### PR DESCRIPTION
Hi Team, this PR adds the following:

- Background conversion of not-iterable values to lists in Multiselect fields.