### PR TITLE
SPT-6028 Filtering when the field type does not match the comparison value should throw an error.

### DIFF
--- a/functional_tests/driver_tests/test_app_reporting_adaptor.py
+++ b/functional_tests/driver_tests/test_app_reporting_adaptor.py
@@ -159,8 +159,8 @@ class TestReportFilteringAdaptor:
     def test_reporting_filter_bad_value_type(helpers):
         report = pytest.app.reports.build(
             'report-%s' % pytest.fake.word(), limit=0)
-        report.filter('Numeric', 'equals', 'Hello')
-        assert len(report) == 0
+        with pytest.raises(ValueError) as excinfo:
+            report.filter('Numeric', 'equals', 'Hello')
 
     @pytest.mark.xfail(reason="SPT-6305: Pydriver should verify that the filedName should be a valid value")
     def test_reporting_invalid_field_name_type(helpers):

--- a/functional_tests/driver_tests/test_records_adaptor.py
+++ b/functional_tests/driver_tests/test_records_adaptor.py
@@ -142,13 +142,10 @@ class TestRecordAdaptorSearch:
         assert str(excinfo.value) == '"<App: %s (%s)> has no field \'%s\'"' % (
             pytest.app.name, pytest.app.acronym, randomFieldName)
 
-    @pytest.mark.xfail(reason="SPT-6028: When the field and comparison values are not the same type, an error should be thrown.")
     def test_record_search_invalid_value(helpers):
         randomFieldName = 'Numeric'
-        with pytest.raises(exceptions.UnknownField) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             pytest.app.records.search((randomFieldName, 'equals', 'Blah'))
-        assert str(excinfo.value) == '"<App: %s (%s)> has no field \'%s\'"' % (
-            pytest.app.name, pytest.app.acronym, randomFieldName)
 
 
 class TestRecordAdaptorDelete:

--- a/functional_tests/driver_tests/test_records_bulk_adaptor.py
+++ b/functional_tests/driver_tests/test_records_bulk_adaptor.py
@@ -137,15 +137,12 @@ class TestRecordAdaptorBulkDelete:
             pytest.app.name, pytest.app.acronym, randomFieldName)
         assert len(pytest.app.records.search()) == startRecordCount
 
-    @pytest.mark.xfail(reason="SPT-6028: When the field and comparison values are not the same type, an error should be thrown.")
     def test_record_bulk_delete_filter_invalid_value(helpers):
         randomFieldName = 'Numeric'
-        with pytest.raises(exceptions.UnknownField) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             records = pytest.app.records.bulk_delete(
                 (randomFieldName, 'equals', 'Hello world'))
             pytest.waitOnJobByID(records)
-        assert str(excinfo.value) == '"<App: %s (%s)> has no field \'%s\'"' % (
-            pytest.app.name, pytest.app.acronym, randomFieldName)
 
     def test_record_bulk_delete_list_twice(helpers):
         textValue = str(uuid.uuid4())
@@ -235,15 +232,12 @@ class TestRecordAdaptorBulkModify:
         assert len(pytest.app.records.search(
             ('Numeric', 'equals', 9999))) == initialRecords
 
-    @pytest.mark.xfail(reason="SPT-6028: When the field and comparison values are not the same type, an error should be thrown.")
     def test_record_bulk_modify_filter_invalid_value(helpers):
         randomValue = 'Fun with numbers'
-        with pytest.raises(exceptions.UnknownField) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             records = pytest.app.records.bulk_modify(
                 ('Numeric', 'equals', randomValue), values={'Numeric': 4444})
             pytest.waitOnJobByID(records)
-        assert str(excinfo.value) == '"<App: %s (%s)> has no field \'%s\'"' % (
-            pytest.app.name, pytest.app.acronym, randomValue)
 
     def test_record_bulk_modify_list(helpers):
         i = random.randint(0,99)

--- a/swimlane/core/adapters/record.py
+++ b/swimlane/core/adapters/record.py
@@ -5,7 +5,7 @@ from swimlane.core.cache import check_cache
 from swimlane.core.resolver import AppResolver
 from swimlane.core.resources.record import Record, record_factory
 from swimlane.core.resources.report import Report
-from swimlane.utils import random_string, one_of_keyword_only
+from swimlane.utils import random_string, one_of_keyword_only, validate_type
 from swimlane.utils.version import requires_swimlane_version
 
 
@@ -417,17 +417,3 @@ def validate_filters_or_records(filters_or_records):
             raise ValueError("Expected filter tuple or Record, received {0}".format(item))
 
     return _type
-
-def validate_type(field, value):
-    """Type validation for filters and fields from bulk_modify, bulk_delete and filter"""
-    accepted_values_to_check = (int, str, float, list, bool, tuple)
-    should_check_value_type = not value == None and type(value) in accepted_values_to_check
-    if should_check_value_type:
-        value_list = value if isinstance(value, list) else [value]
-        for v in value_list:
-            wrong_type = not any(
-                    [isinstance(v, field_type) for field_type in field.supported_types]
-            ) if len(field.supported_types) > 0 else False
-
-            if wrong_type:
-                raise ValueError("Value must be one of {}".format(", ".join([str(f) for f in field.supported_types])))

--- a/swimlane/core/resources/report.py
+++ b/swimlane/core/resources/report.py
@@ -4,6 +4,7 @@ from swimlane.core.cursor import PaginatedCursor
 from swimlane.core.resources.base import APIResource
 from swimlane.core.resources.record import Record, record_factory
 from swimlane.core.search import CONTAINS, EQ, EXCLUDES, NOT_EQ, LT, GT, LTE, GTE, ASC, DESC
+from swimlane.utils import validate_type
 
 
 class Report(APIResource, PaginatedCursor):
@@ -113,17 +114,7 @@ class Report(APIResource, PaginatedCursor):
 
         field = self._get_stub_field(field_name)
         
-        accepted_values_to_check = (int, str, float, list, bool, tuple)
-        should_check_value_type = not value == None and type(value) in accepted_values_to_check
-        if should_check_value_type:
-            value_list = value if isinstance(value, list) else [value]
-            for v in value_list:
-                wrong_type = not any(
-                        [isinstance(v, field_type) for field_type in field.supported_types]
-                ) if len(field.supported_types) > 0 else False
-
-                if wrong_type:
-                    raise ValueError("Value must be one of {}".format(", ".join([str(f) for f in field.supported_types])))
+        validate_types(field, value)
 
         self._raw['filters'].append({
             "fieldId": field.id,

--- a/swimlane/core/resources/report.py
+++ b/swimlane/core/resources/report.py
@@ -114,7 +114,7 @@ class Report(APIResource, PaginatedCursor):
 
         field = self._get_stub_field(field_name)
         
-        validate_types(field, value)
+        validate_type(field, value)
 
         self._raw['filters'].append({
             "fieldId": field.id,

--- a/swimlane/utils/__init__.py
+++ b/swimlane/utils/__init__.py
@@ -116,3 +116,17 @@ def one_of_keyword_only(*valid_keywords):
 
     return decorator
 
+
+def validate_type(field, value):
+    """Type validation for filters and fields from bulk_modify, bulk_delete and filter"""
+    accepted_values_to_check = (int, str, float, list, bool, tuple)
+    should_check_value_type = not value == None and type(value) in accepted_values_to_check
+    if should_check_value_type:
+        value_list = value if isinstance(value, list) else [value]
+        for v in value_list:
+            wrong_type = not any(
+                    [isinstance(v, field_type) for field_type in field.supported_types]
+            ) if len(field.supported_types) > 0 else False
+
+            if wrong_type:
+                raise ValueError("Value must be one of {}".format(", ".join([str(f) for f in field.supported_types])))


### PR DESCRIPTION
The validation verifies if primitive types match before doing a search/filter, bulk delete or bulk modify.

Same logic was duplicated inside records and report. If there is a utils/helper file where those two can share logic, that would be nice.

[Link to SPT](https://swimlane.atlassian.net/browse/SPT-6028)