### PR TITLE
SPT-6352: First created and last updated (user and date stamp) should throw error when user tries to set value

### DIFF
--- a/functional_tests/driver_tests/test_date_time_fields.py
+++ b/functional_tests/driver_tests/test_date_time_fields.py
@@ -166,22 +166,20 @@ class TestFirstCreatedField:
             **{"Required Date & Time": pendulum.now()})
         assert theRecord["First Created"] != None
 
-    @pytest.mark.xfail(reason="SPT-6352: The First created should have been blocked from being set.")
     def test_first_created_field(helpers):
         datetimeValue = pendulum.tomorrow()
-        theRecord = pytest.app.records.create(
+        with pytest.raises(ValueError) as excinfo:
+            pytest.app.records.create(
             **{"Required Date & Time": pendulum.now(), "First Created": datetimeValue})
-        assert theRecord["First Created"] != datetimeValue
+        assert str(excinfo.value) == 'Input type "firstCreated" is not editable'
 
-    @pytest.mark.xfail(reason="SPT-6352: The First created should have been blocked from being set.")
     def test_first_created_field_on_save(helpers):
         datetimeValue = pendulum.tomorrow()
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
-        theOriginalTimeCreated = theRecord["First Created"]
-        theRecord["First Created"] = datetimeValue
-        theRecord.save()
-        assert theRecord["First Created"] == theOriginalTimeCreated
+        with pytest.raises(ValueError) as excinfo:
+            theRecord["First Created"] = datetimeValue
+        assert str(excinfo.value) == 'Input type "firstCreated" is not editable'
 
 
 class TestLastUpdatedField:
@@ -190,22 +188,20 @@ class TestLastUpdatedField:
             **{"Required Date & Time": pendulum.now()})
         assert theRecord["Last Updated"] >= theRecord["First Created"]
 
-    @pytest.mark.xfail(reason="SPT-6352: The Last updated should have been blocked from being set.")
     def test_last_updated_field(helpers):
         datetimeValue = pendulum.yesterday()
-        theRecord = pytest.app.records.create(
-            **{"Required Date & Time": pendulum.now(), "Last Updated": datetimeValue})
-        assert theRecord["Last Updated"] != datetimeValue
+        with pytest.raises(ValueError) as excinfo:
+            pytest.app.records.create(
+                **{"Required Date & Time": pendulum.now(), "Last Updated": datetimeValue})
+        assert str(excinfo.value) == 'Input type "lastUpdated" is not editable'
 
-    @pytest.mark.xfail(reason="SPT-6352: The Last updated should have been blocked from being set.")
     def test_last_updated_field_on_save(helpers):
         datetimeValue = pendulum.yesterday()
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
-        theRecord["Last Updated"] = datetimeValue
-        theRecord.save()
-        assert theRecord["First Created"] < theRecord["Last Updated"]
-        assert theRecord["Last Updated"] != datetimeValue
+        with pytest.raises(ValueError) as excinfo:
+            theRecord["Last Updated"] = datetimeValue
+        assert str(excinfo.value) == 'Input type "lastUpdated" is not editable'
 
 
 class TestTimespanField:

--- a/functional_tests/driver_tests/test_records_bulk_adaptor.py
+++ b/functional_tests/driver_tests/test_records_bulk_adaptor.py
@@ -396,49 +396,41 @@ class TestRecordAdaptorBulkModifyClear:
         baseTime = pendulum.now()
         pytest.app.records.bulk_create({'Date & Time': baseTime}, {'Date & Time': baseTime}, {
                                        'Date & Time': baseTime}, {'Date & Time': baseTime})
-        emptyNumericRecords = len(pytest.app.records.search(
-            ('First Created', 'equals', None)))
-        records = pytest.app.records.bulk_modify(
-            ('Date & Time', 'equals', baseTime), values={'First Created': Clear()})
-        pytest.waitOnJobByID(records)
-        assert len(pytest.app.records.search(
-            ('First Created', 'equals', None))) == emptyNumericRecords
+        with pytest.raises(ValueError) as excinfo:
+            records = pytest.app.records.bulk_modify(
+                ('Date & Time', 'equals', baseTime), values={'First Created': Clear()})
+            pytest.waitOnJobByID(records)
+        assert str(excinfo.value) == 'Input type "firstCreated" is not editable'
 
     def test_record_bulk_modify_clear_last_updated(helpers):
         baseTime = pendulum.now()
         pytest.app.records.bulk_create({'Date & Time': baseTime}, {'Date & Time': baseTime}, {
                                        'Date & Time': baseTime}, {'Date & Time': baseTime})
-        emptyNumericRecords = len(pytest.app.records.search(
-            ('Last Updated', 'equals', None)))
-        records = pytest.app.records.bulk_modify(
-            ('Date & Time', 'equals', baseTime), values={'Last Updated': Clear()})
-        pytest.waitOnJobByID(records)
-        assert len(pytest.app.records.search(
-            ('Last Updated', 'equals', None))) == emptyNumericRecords
+        with pytest.raises(ValueError) as excinfo:
+            records = pytest.app.records.bulk_modify(
+                ('Date & Time', 'equals', baseTime), values={'Last Updated': Clear()})
+            pytest.waitOnJobByID(records)
+        assert str(excinfo.value) == 'Input type "lastUpdated" is not editable'
 
     def test_record_bulk_modify_clear_created_by(helpers):
         baseTime = pendulum.now()
         pytest.app.records.bulk_create({'Date & Time': baseTime}, {'Date & Time': baseTime}, {
                                        'Date & Time': baseTime}, {'Date & Time': baseTime})
-        emptyNumericRecords = len(
-            pytest.app.records.search(('Created by', 'equals', None)))
-        records = pytest.app.records.bulk_modify(
-            ('Date & Time', 'equals', baseTime), values={'Created by': Clear()})
-        pytest.waitOnJobByID(records)
-        assert len(pytest.app.records.search(
-            ('Created by', 'equals', None))) == emptyNumericRecords
+        with pytest.raises(ValueError) as excinfo:
+            records = pytest.app.records.bulk_modify(
+                ('Date & Time', 'equals', baseTime), values={'Created by': Clear()})
+            pytest.waitOnJobByID(records)
+        assert str(excinfo.value) == 'Input type "createdBy" is not editable'
 
     def test_record_bulk_modify_clear_last_updated_by(helpers):
         baseTime = pendulum.now()
         pytest.app.records.bulk_create({'Date & Time': baseTime}, {'Date & Time': baseTime}, {
                                        'Date & Time': baseTime}, {'Date & Time': baseTime})
-        emptyNumericRecords = len(pytest.app.records.search(
-            ('Last updated by', 'equals', None)))
-        records = pytest.app.records.bulk_modify(
-            ('Date & Time', 'equals', baseTime), values={'Last updated by': Clear()})
-        pytest.waitOnJobByID(records)
-        assert len(pytest.app.records.search(
-            ('Last updated by', 'equals', None))) == emptyNumericRecords
+        with pytest.raises(ValueError) as excinfo:
+            records = pytest.app.records.bulk_modify(
+                ('Date & Time', 'equals', baseTime), values={'Last updated by': Clear()})
+            pytest.waitOnJobByID(records)
+        assert str(excinfo.value) == 'Input type "lastUpdatedBy" is not editable'
 
     def test_record_bulk_modify_clear_attachment(helpers):
         baseText = "Has Attachment"

--- a/functional_tests/driver_tests/test_user_group_fields.py
+++ b/functional_tests/driver_tests/test_user_group_fields.py
@@ -144,25 +144,24 @@ class TestCreatedByField:
             **{"Required User/Groups": swimUser})
         assert theRecord["Created by"] == swimUser
 
-    @pytest.mark.xfail(reason="SPT-6352: This should fail, that the Created by is read only.")
     def test_created_by_field(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
         swimUser2 = pytest.swimlane_instance.users.get(
             display_name=pytest.testUsers[pytest.fake.random_int(0, len(pytest.testUsers)-1)])
-        theRecord = pytest.app.records.create(
-            **{"Required User/Groups": swimUser, "Created by": swimUser2})
-        assert theRecord["Created by"] == swimUser
+        with pytest.raises(ValueError) as excinfo:
+            pytest.app.records.create(
+                **{"Required User/Groups": swimUser, "Created by": swimUser2})
+        assert str(excinfo.value) == 'Input type "createdBy" is not editable'
 
-    @pytest.mark.xfail(reason="SPT-6352: This should fail, that the Created by is read only.")
     def test_created_by_field_on_save(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
         swimUser2 = pytest.swimlane_instance.users.get(
             display_name=pytest.testUsers[pytest.fake.random_int(0, len(pytest.testUsers)-1)])
         theRecord = pytest.app.records.create(
             **{"Required User/Groups": swimUser})
-        theRecord["Created by"] = swimUser2
-        theRecord.save()
-        assert theRecord["Created by"] == swimUser
+        with pytest.raises(ValueError) as excinfo:
+            theRecord["Created by"] = swimUser2
+        assert str(excinfo.value) == 'Input type "createdBy" is not editable'
 
 
 class TestLastUpdatedByField:
@@ -172,25 +171,25 @@ class TestLastUpdatedByField:
             **{"Required User/Groups": swimUser})
         assert theRecord["Last updated by"] == swimUser
 
-    @pytest.mark.xfail(reason="SPT-6352: This should fail, that the last updated by is read only.")
     def test_last_updated_by_field(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
         swimUser2 = pytest.swimlane_instance.users.get(
             display_name=pytest.testUsers[pytest.fake.random_int(0, len(pytest.testUsers)-1)])
-        theRecord = pytest.app.records.create(
-            **{"Required User/Groups": swimUser, "Last updated by": swimUser2})
-        assert theRecord["Last updated by"] == swimUser
+        with pytest.raises(ValueError) as excinfo:
+            pytest.app.records.create(
+                **{"Required User/Groups": swimUser, "Last updated by": swimUser2})
+        assert str(excinfo.value) == 'Input type "lastUpdatedBy" is not editable'
 
-    @pytest.mark.xfail(reason="SPT-6352: This should fail, that the Last updated by is read only.")
+
     def test_last_updated_by_field_on_save(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
         swimUser2 = pytest.swimlane_instance.users.get(
             display_name=pytest.testUsers[pytest.fake.random_int(0, len(pytest.testUsers)-1)])
         theRecord = pytest.app.records.create(
             **{"Required User/Groups": swimUser})
-        theRecord["Last updated by"] = swimUser2
-        theRecord.save()
-        assert theRecord["Last updated by"] == swimUser
+        with pytest.raises(ValueError) as excinfo:    
+            theRecord["Last updated by"] = swimUser2
+        assert str(excinfo.value) == 'Input type "lastUpdatedBy" is not editable'
 
 
 class TestAllUsersAndGroupsField:

--- a/swimlane/core/fields/base/field.py
+++ b/swimlane/core/fields/base/field.py
@@ -107,6 +107,9 @@ class Field(SwimlaneResolver):
         return self.cast_to_report(value)
 
     def validate_value(self, value):
+        """Validate that the field is editable during set_python operation"""
+        self.validate_editable_field()
+
         """Validate value is an acceptable type during set_python operation"""
         if self.readonly and not self._swimlane._write_to_read_only:
             raise ValidationError(self.record, "Cannot set readonly field '{}'".format(self.name))
@@ -117,6 +120,11 @@ class Field(SwimlaneResolver):
                     ', '.join([repr(t.__name__) for t in self.supported_types]),
                     type(value).__name__)
                 )
+    
+    def validate_editable_field(self):
+        not_editable_input_types = ['firstCreated', 'lastUpdated', 'createdBy', 'lastUpdatedBy']
+        if self.input_type in not_editable_input_types:
+            raise ValueError('Input type "{}" is not editable'.format(self.input_type))
 
     def _set(self, value):
         """Default setter used for both representations unless overridden"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,7 +333,7 @@ def mock_app(mock_swimlane):
                     'fieldType': 'date',
                     'helpTextType': 'none',
                     'id': 'aiir8',
-                    'inputType': 'firstCreated',
+                    'inputType': 'dateTime',
                     'name': 'Incident Created'},
                    {'$type': 'Core.Models.Fields.UserGroupField, Core',
                     'controlType': 'select',

--- a/tests/fields/test_basic.py
+++ b/tests/fields/test_basic.py
@@ -84,7 +84,8 @@ def test_all_fields_empty_value(mock_record, field_class):
     # Get any not readonly field instance of provided field_class
     # Does not guarantee full scope of all field subtypes function as expected
     for field in mock_record._fields.values():
-        if isinstance(field, field_class) and not field.readonly:
+        not_editable_input_types = ['firstCreated', 'lastUpdated', 'createdBy', 'lastUpdatedBy']
+        if isinstance(field, field_class) and not field.readonly and field.input_type in not_editable_input_types:
             del mock_record[field.name]
 
             swimlane = field.get_swimlane()

--- a/tests/fields/test_basic.py
+++ b/tests/fields/test_basic.py
@@ -85,7 +85,7 @@ def test_all_fields_empty_value(mock_record, field_class):
     # Does not guarantee full scope of all field subtypes function as expected
     for field in mock_record._fields.values():
         not_editable_input_types = ['firstCreated', 'lastUpdated', 'createdBy', 'lastUpdatedBy']
-        if isinstance(field, field_class) and not field.readonly and field.input_type in not_editable_input_types:
+        if isinstance(field, field_class) and not field.readonly and not field.input_type in not_editable_input_types:
             del mock_record[field.name]
 
             swimlane = field.get_swimlane()


### PR DESCRIPTION
- Added validation to prevent editing fields with input types: `firstCreated`, `lastUpdated`, `createdBy` and `lastUpdatedBy`
- Updated tests in `test_date_time_fields`, `test_records_bulk_adaptor` and `test_user_group_fields`.