### PR TITLE
SPT-6341: Standardize quoting styles in error messages

### DIFF
--- a/functional_tests/conftest.py
+++ b/functional_tests/conftest.py
@@ -241,9 +241,9 @@ class Helpers:
             if (True in (ele['status'] == 'completed' for ele in loggingStuff)):
                 break
             elif (True in (ele['status'] == 'failed' for ele in loggingStuff)):
-                raise Exception("Batch Job failed")
+                raise Exception('Batch Job failed')
             elif (sleepTime > 30):
-                raise Exception("Timed out waiting for the job to complete")
+                raise Exception('Timed out waiting for the job to complete')
             else:
                 time.sleep(0.1)
                 sleepTime += 0.1

--- a/functional_tests/driver_tests/test_attachment_fields.py
+++ b/functional_tests/driver_tests/test_attachment_fields.py
@@ -109,7 +109,7 @@ class TestReadOnlyAttachmentField:
         theFile = pytest.helpers.loadFileStream(fileName)
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord['ReadOnly Attachment'].add(fileName, theFile)
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field \'ReadOnly Attachment\'' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field "ReadOnly Attachment"' % theRecord.tracking_id
         theRecord.save()
         updatedRecord = pytest.app.records.get(id=theRecord.id)
         assert len(updatedRecord['Attachment']) == 0

--- a/functional_tests/driver_tests/test_date_time_fields.py
+++ b/functional_tests/driver_tests/test_date_time_fields.py
@@ -46,27 +46,27 @@ class TestDateTimeField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Date & Time": pendulum.now(), "Date & Time": pendulum.now().date()})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Date & Time\' expects one of \'datetime\', got \'Date\' instead' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Date & Time" expects one of \'datetime\', got "Date" instead' % pytest.app.acronym
 
     def test_datetime_field_date_on_save(helpers):
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Date & Time"] = pendulum.now().date()
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Date & Time\' expects one of \'datetime\', got \'Date\' instead' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Date & Time" expects one of \'datetime\', got "Date" instead' % theRecord.tracking_id
 
     def test_datetime_field_time(helpers):
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Date & Time": pendulum.now(), "Date & Time": pendulum.now().time()})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Date & Time\' expects one of \'datetime\', got \'Time\' instead' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Date & Time" expects one of \'datetime\', got "Time" instead' % pytest.app.acronym
 
     def test_datetime_field_time_on_save(helpers):
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Date & Time"] = pendulum.now().time()
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Date & Time\' expects one of \'datetime\', got \'Time\' instead' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Date & Time" expects one of \'datetime\', got "Time" instead' % theRecord.tracking_id
 
 
 class TestDateField:
@@ -98,27 +98,27 @@ class TestDateField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Date & Time": pendulum.now(), "Date": pendulum.now().to_date_string()})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Date\' expects one of \'datetime\', \'date\', got \'str\' instead' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Date" expects one of \'datetime\', \'date\', got "str" instead' % pytest.app.acronym
 
     def test_date_field_string_on_save(helpers):
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Date"] = pendulum.now().to_date_string()
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Date\' expects one of \'datetime\', \'date\', got \'str\' instead' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Date" expects one of \'datetime\', \'date\', got "str" instead' % theRecord.tracking_id
 
     def test_date_field_time(helpers):
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Date & Time": pendulum.now(), "Date": pendulum.now().time()})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Date\' expects one of \'datetime\', \'date\', got \'Time\' instead' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Date" expects one of \'datetime\', \'date\', got "Time" instead' % pytest.app.acronym
 
     def test_date_field_time_on_save(helpers):
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Date"] = pendulum.now().time()
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Date\' expects one of \'datetime\', \'date\', got \'Time\' instead' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Date" expects one of \'datetime\', \'date\', got "Time" instead' % theRecord.tracking_id
 
 
 class TestTimeField:
@@ -150,14 +150,14 @@ class TestTimeField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Date & Time": pendulum.now(), "Time": pendulum.now().date()})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Time\' expects one of \'datetime\', \'time\', got \'Date\' instead' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Time" expects one of \'datetime\', \'time\', got "Date" instead' % pytest.app.acronym
 
     def test_time_field_date_on_save(helpers):
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Time"] = pendulum.now().date()
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Time\' expects one of \'datetime\', \'time\', got \'Date\' instead' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Time" expects one of \'datetime\', \'time\', got "Date" instead' % theRecord.tracking_id
 
 
 class TestFirstCreatedField:
@@ -228,27 +228,27 @@ class TestTimespanField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Date & Time": pendulum.now(), "Timespan": pendulum.now()})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Timespan\' expects one of \'timedelta\', got \'DateTime\' instead' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Timespan" expects one of \'timedelta\', got "DateTime" instead' % pytest.app.acronym
 
     def test_timespan_field_datetime_on_save(helpers):
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Timespan"] = pendulum.now()
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Timespan\' expects one of \'timedelta\', got \'DateTime\' instead' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Timespan" expects one of \'timedelta\', got "DateTime" instead' % theRecord.tracking_id
 
     def test_timespan_field_number(helpers):
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Date & Time": pendulum.now(), "Timespan": 123})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Timespan\' expects one of \'timedelta\', got \'int\' instead' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Timespan" expects one of \'timedelta\', got "int" instead' % pytest.app.acronym
 
     def test_timespan_field_number_on_save(helpers):
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Timespan"] = 123
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Timespan\' expects one of \'timedelta\', got \'int\' instead' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Timespan" expects one of \'timedelta\', got "int" instead' % theRecord.tracking_id
 
     def test_timespan_field_pendulum_interval(helpers):
         delta = pendulum.duration(days=15)
@@ -271,14 +271,14 @@ class TestReadOnlyDateTimeField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Date & Time": pendulum.now(), "Read-only Date & Time": pendulum.now()})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Cannot set readonly field \'Read-only Date & Time\'' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Cannot set readonly field "Read-only Date & Time"' % pytest.app.acronym
 
     def test_readonly_datetime_on_save(helpers):
         theRecord = pytest.app.records.create(
             **{"Required Date & Time": pendulum.now()})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Read-only Date & Time"] = pendulum.now()
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field \'Read-only Date & Time\'' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field "Read-only Date & Time"' % theRecord.tracking_id
 
 
 class TestDefaultCurrentDateTimeField:

--- a/functional_tests/driver_tests/test_numeric_fields.py
+++ b/functional_tests/driver_tests/test_numeric_fields.py
@@ -101,7 +101,7 @@ class TestListNumericField:
             **{"Required Numeric": 101, "Numeric List": NumericValue})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord['Numeric List'].insert(2, newValue)
-        assert str(excinfo.value) == "Validation failed for <Record: %s>. Reason: Numeric list field items must be numbers, not '%s'" % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Numeric list field items must be numbers, not "%s"' % (
             theRecord.tracking_id, pytest.py_ver_string_type())
 
     def test_list_Numeric_field_on_save_append(helpers):
@@ -121,7 +121,7 @@ class TestListNumericField:
             **{"Required Numeric": 101, "Numeric List": NumericValue})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord['Numeric List'].append(newValue)
-        assert str(excinfo.value) == "Validation failed for <Record: %s>. Reason: Numeric list field items must be numbers, not '%s'" % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Numeric list field items must be numbers, not "%s"' % (
             theRecord.tracking_id, pytest.py_ver_string_type())
 
 
@@ -150,13 +150,13 @@ class TestMinValueNumericField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Numeric": 101, "Min Numeric": 2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Min Numeric\' minimum value \'3.0\', received \'2\'' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Min Numeric" minimum value "3.0", received "2"' % pytest.app.acronym
 
     def test_min_count_on_save_too_low(helpers):
         theRecord = pytest.app.records.create(**{"Required Numeric": 101})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Min Numeric"] = 2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Min Numeric\' minimum value \'3.0\', received \'2\'' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Min Numeric" minimum value "3.0", received "2"' % theRecord.tracking_id
 
 
 class TestMaxValueNumericField:
@@ -184,13 +184,13 @@ class TestMaxValueNumericField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Numeric": 101, "Max Numeric": 102})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Max Numeric\' maximum value \'100.0\', received \'102\'' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Max Numeric" maximum value "100.0", received "102"' % pytest.app.acronym
 
     def test_max_value_on_save_too_high(helpers):
         theRecord = pytest.app.records.create(**{"Required Numeric": 101})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Max Numeric"] = 102
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Max Numeric\' maximum value \'100.0\', received \'102\'' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Max Numeric" maximum value "100.0", received "102"' % theRecord.tracking_id
 
 
 class TestMinMaxValueNumericField:
@@ -228,22 +228,22 @@ class TestMinMaxValueNumericField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Numeric": 101, "Min Max Numeric": 2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Min Max Numeric\' minimum value \'3.0\', received \'2\'' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Min Max Numeric" minimum value "3.0", received "2"' % pytest.app.acronym
 
     def test_min_count_on_save_too_low(helpers):
         theRecord = pytest.app.records.create(**{"Required Numeric": 101})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Min Max Numeric"] = 2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Min Max Numeric\' minimum value \'3.0\', received \'2\'' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Min Max Numeric" minimum value "3.0", received "2"' % theRecord.tracking_id
 
     def test_max_value_too_high(helpers):
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Numeric": 101, "Min Max Numeric": 102})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'Min Max Numeric\' maximum value \'100.0\', received \'102\'' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "Min Max Numeric" maximum value "100.0", received "102"' % pytest.app.acronym
 
     def test_max_value_on_save_too_high(helpers):
         theRecord = pytest.app.records.create(**{"Required Numeric": 101})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Min Max Numeric"] = 102
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'Min Max Numeric\' maximum value \'100.0\', received \'102\'' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "Min Max Numeric" maximum value "100.0", received "102"' % theRecord.tracking_id

--- a/functional_tests/driver_tests/test_record_restriction_adaptor.py
+++ b/functional_tests/driver_tests/test_record_restriction_adaptor.py
@@ -99,7 +99,7 @@ class TestRecordRestrictByUser:
         with pytest.raises(ValueError) as excinfo:
             tempRecord.remove_restriction(
                 pytest.swimlane_instance.users.get(id=pytest.newUser1['id']))
-        assert str(excinfo.value) == 'UserGroup `%s` not in record `%s` restriction list' % (
+        assert str(excinfo.value) == 'UserGroup "%s" not in record "%s" restriction list' % (
             pytest.newUser1['name'], tempRecord.tracking_id)
         assert len(restrictionsList) == 1
         assert restrictionsList == tempRecord.restrictions
@@ -110,7 +110,7 @@ class TestRecordRestrictByUser:
         users = None
         with pytest.raises(TypeError) as excinfo:
             tempRecord.add_restriction(users)
-        assert str(excinfo.value) == "Expected UserGroup, received `None` instead"
+        assert str(excinfo.value) == 'Expected UserGroup, received "None" instead'
         assert len(tempRecord.restrictions) == 0
 
     def test_restriction_add_duplicate_user(helpers):
@@ -194,7 +194,7 @@ class TestRecordRestrictByGroup:
             id=pytest.newGroup2['id'])
         with pytest.raises(ValueError) as excinfo:
             tempRecord.remove_restriction(swimGroup2)
-        assert str(excinfo.value) == 'UserGroup `%s` not in record `%s` restriction list' % (
+        assert str(excinfo.value) == 'UserGroup "%s" not in record "%s" restriction list' % (
             pytest.newGroup2['name'], tempRecord.tracking_id)
         assert len(tempRecord.restrictions) == 1
         assert restrictionsList == tempRecord.restrictions

--- a/functional_tests/driver_tests/test_records_bulk_adaptor.py
+++ b/functional_tests/driver_tests/test_records_bulk_adaptor.py
@@ -76,7 +76,7 @@ class TestRecordAdaptorBulkCreate:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.bulk_create({randomFieldName: 'Frank did it'}, {
                                            randomFieldName: 123456}, {randomFieldName: 123456}, {randomFieldName: 123456})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field \'%s\' expects one of \'Number\', got \'str\' instead' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Field "%s" expects one of \'Number\', got "str" instead' % (
             pytest.app.acronym, randomFieldName)
         emptyRecords = pytest.app.records.search(
             (randomFieldName, 'equals', 123456))
@@ -475,7 +475,7 @@ class TestRecordAdaptorBulkModifyClear:
             pytest.app.records.bulk_modify(
                 ('Text', 'equals', baseText), values={'Attachment': Clear()})
         assert str(
-            excinfo.value) == 'Field \'Attachment\' of Type \'AttachmentsField\', is not supported for bulk modify'
+            excinfo.value) == 'Field "Attachment" of Type "AttachmentsField", is not supported for bulk modify'
 
     def test_record_bulk_modify_clear_comments(helpers):
         baseText = "Has Comment"
@@ -488,7 +488,7 @@ class TestRecordAdaptorBulkModifyClear:
             pytest.app.records.bulk_modify(
                 ('Text', 'equals', baseText), values={'Attachment': Clear()})
         assert str(
-            excinfo.value) == 'Field \'Attachment\' of Type \'AttachmentsField\', is not supported for bulk modify'
+            excinfo.value) == 'Field "Attachment" of Type "AttachmentsField", is not supported for bulk modify'
 
     def test_record_bulk_modify_clear_references(helpers):
         baseText = "Has Reference"
@@ -696,7 +696,7 @@ class TestRecordAdaptorBulkModifyAppend:
             pytest.app.records.bulk_modify(('Text', 'equals', baseText), values={
                                            'Attachment': Append(theFile)})
         assert str(
-            excinfo.value) == 'Field \'Attachment\' of Type \'AttachmentsField\', is not supported for bulk modify'
+            excinfo.value) == 'Field "Attachment" of Type "AttachmentsField", is not supported for bulk modify'
 
     def test_record_bulk_modify_append_comments(helpers):
         baseText = str(uuid.uuid4())
@@ -706,7 +706,7 @@ class TestRecordAdaptorBulkModifyAppend:
             pytest.app.records.bulk_modify(('Text', 'equals', baseText), values={
                                            'Attachment': Append(baseText)})
         assert str(
-            excinfo.value) == 'Field \'Attachment\' of Type \'AttachmentsField\', is not supported for bulk modify'
+            excinfo.value) == 'Field "Attachment" of Type "AttachmentsField", is not supported for bulk modify'
 
     @pytest.mark.xfail(reason="SPT-7932: There was no error about the field type, but the passed in targetRecord, which is a record class, thinks it is a tuple??")
     def test_record_bulk_modify_append_references(helpers):
@@ -890,7 +890,7 @@ class TestRecordAdaptorBulkModifyRemove:
             pytest.app.records.bulk_modify(('Text', 'equals', baseText), values={
                 'Attachment': Remove(theFile)})
         assert str(
-            excinfo.value) == 'Field \'Attachment\' of Type \'AttachmentsField\', is not supported for bulk modify'
+            excinfo.value) == 'Field "Attachment" of Type "AttachmentsField", is not supported for bulk modify'
 
     def test_record_bulk_modify_remove_comments(helpers):
         baseText = str(uuid.uuid4())
@@ -900,7 +900,7 @@ class TestRecordAdaptorBulkModifyRemove:
             pytest.app.records.bulk_modify(('Text', 'equals', baseText), values={
                 'Attachment': Remove(baseText)})
         assert str(
-            excinfo.value) == 'Field \'Attachment\' of Type \'AttachmentsField\', is not supported for bulk modify'
+            excinfo.value) == 'Field "Attachment" of Type "AttachmentsField", is not supported for bulk modify'
 
     @pytest.mark.xfail(reason="SPT-7932: There was no error about the field type, but the passed in targetRecord, which is a record class, thinks it is a tuple??")
     def test_record_bulk_modify_remove_references(helpers):

--- a/functional_tests/driver_tests/test_records_readonly_overwrite.py
+++ b/functional_tests/driver_tests/test_records_readonly_overwrite.py
@@ -24,7 +24,7 @@ class Test_SPT_4287_readonly_override:
         assert len(fullRecord.revisions.get_all()) == 1
         with pytest.raises(exceptions.ValidationError) as excinfo:
             fullRecord['Read Only Numeric'] = 5
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field \'Read Only Numeric\'' % fullRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field "Read Only Numeric"' % fullRecord.tracking_id
 
     def test_readonly_override_set(helpers):
         new_instance = pytest.helpers.reconnect_swimlane(

--- a/functional_tests/driver_tests/test_selection_fields.py
+++ b/functional_tests/driver_tests/test_selection_fields.py
@@ -51,7 +51,7 @@ class TestSingleSelectField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Single-select": "a", "Single-select": ["two", "three"]})
-        assert str(excinfo.value) == "Validation failed for <Record: {} - New>. Reason: Field 'Single-select' expects one of '{}', got 'list' instead".format(
+        assert str(excinfo.value) == 'Validation failed for <Record: {} - New>. Reason: Field "Single-select" expects one of \'{}\', got "list" instead'.format(
             pytest.app.acronym, ("str", "basestring")[pytest.py_ver() == 2])
 
     def test_single_select_field_multiple_on_save(helpers):
@@ -59,7 +59,7 @@ class TestSingleSelectField:
             **{"Required Single-select": "a"})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Single-select"] = ["two", "three"]
-        assert str(excinfo.value) == "Validation failed for <Record: {}>. Reason: Field 'Single-select' expects one of '{}', got 'list' instead".format(
+        assert str(excinfo.value) == 'Validation failed for <Record: {}>. Reason: Field "Single-select" expects one of \'{}\', got "list" instead'.format(
             theRecord.tracking_id, ("str", "basestring")[pytest.py_ver() == 2])
 
     def test_single_select_field_empty(helpers):
@@ -107,7 +107,7 @@ class TestSingleSelectField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Single-select": "a", "Single-select": 1})
-        assert str(excinfo.value) == "Validation failed for <Record: {} - New>. Reason: Field 'Single-select' expects one of '{}', got 'int' instead".format(
+        assert str(excinfo.value) == 'Validation failed for <Record: {} - New>. Reason: Field "Single-select" expects one of \'{}\', got "int" instead'.format(
             pytest.app.acronym, ("str", "basestring")[pytest.py_ver() == 2])
 
     def test_single_select_field_int_on_save(helpers):
@@ -115,7 +115,7 @@ class TestSingleSelectField:
             **{"Required Single-select": "a"})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Single-select"] = 123
-        assert str(excinfo.value) == "Validation failed for <Record: {}>. Reason: Field 'Single-select' expects one of '{}', got 'int' instead".format(
+        assert str(excinfo.value) == 'Validation failed for <Record: {}>. Reason: Field "Single-select" expects one of \'{}\', got "int" instead'.format(
             theRecord.tracking_id, ("str", "basestring")[pytest.py_ver() == 2])
 
 
@@ -177,7 +177,7 @@ class TestMultiSelectField:
             **{"Required Single-select": "a", "Multi-select": ["first", "second"]})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Multi-select"].select(2)
-        assert str(excinfo.value) == "Validation failed for <Record: {}>. Reason: Field 'Multi-select' expects one of '{}', got 'int' instead".format(
+        assert str(excinfo.value) == 'Validation failed for <Record: {}>. Reason: Field "Multi-select" expects one of \'{}\', got "int" instead'.format(
             theRecord.tracking_id, ("str", "basestring")[pytest.py_ver() == 2])
 
     def test_multi_select_field_deselect_value_int_on_save(helpers):
@@ -193,14 +193,14 @@ class TestReadOnlySelectField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required Single-select": "a", "Read-only Single-select": "aa"})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Cannot set readonly field \'Read-only Single-select\'' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Cannot set readonly field "Read-only Single-select"' % pytest.app.acronym
 
     def test_read_only_field_on_save(helpers):
         theRecord = pytest.app.records.create(
             **{"Required Single-select": "a"})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Read-only Single-select"] = "aa"
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field \'Read-only Single-select\'' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field "Read-only Single-select"' % theRecord.tracking_id
 
 
 class TestDefaultSelectField:

--- a/functional_tests/driver_tests/test_text_fields.py
+++ b/functional_tests/driver_tests/test_text_fields.py
@@ -269,7 +269,7 @@ class TestJSONTextField:
             pytest.app.records.create(
                 **{"Required Text": "required", "JSON": textValue})
         assert str(
-            excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Cannot set readonly field \'JSON\'' % pytest.app.acronym
+            excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Cannot set readonly field "JSON"' % pytest.app.acronym
 
     # @pytest.mark.xfail(reason="SPT-6362: SHOULD JSON be writable from pydriver??")
     def test_json_text_field_on_save(helpers):
@@ -278,7 +278,7 @@ class TestJSONTextField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord['JSON'] = textValue
         assert str(
-            excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field \'JSON\'' % theRecord.tracking_id
+            excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field "JSON"' % theRecord.tracking_id
 
 
 class TestListTextField:
@@ -318,7 +318,7 @@ class TestListTextField:
             **{"Required Text": "required", "Text List": textValue})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord['Text List'].insert(2, newValue)
-        assert str(excinfo.value) == "Validation failed for <Record: {}>. Reason: Text list field items must be strings, not '<{} 'int'>'".format(
+        assert str(excinfo.value) == 'Validation failed for <Record: {}>. Reason: Text list field items must be strings, not "<{} \'int\'>"'.format(
             theRecord.tracking_id, ("class", "type")[pytest.helpers.py_ver() == 2])
 
     def test_list_text_field_on_save_append(helpers):
@@ -338,7 +338,7 @@ class TestListTextField:
             **{"Required Text": "required", "Text List": textValue})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord['Text List'].append(newValue)
-        assert str(excinfo.value) == "Validation failed for <Record: {}>. Reason: Text list field items must be strings, not '<{} 'int'>'".format(
+        assert str(excinfo.value) == 'Validation failed for <Record: {}>. Reason: Text list field items must be strings, not "<{} \'int\'>"'.format(
             theRecord.tracking_id, ("class", "type")[pytest.helpers.py_ver() == 2])
 
 

--- a/functional_tests/driver_tests/test_user_group_fields.py
+++ b/functional_tests/driver_tests/test_user_group_fields.py
@@ -62,7 +62,7 @@ class TestUserGroupField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "User/Groups": swimGroup})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `User/Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "User/Groups"' % (
             pytest.app.acronym, swimGroup.name)
 
     def test_user_group_field_on_save_bad_type_group(helpers):
@@ -73,7 +73,7 @@ class TestUserGroupField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["User/Groups"] = swimGroup
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `User/Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "User/Groups"' % (
             theRecord.tracking_id, swimGroup.name)
 
 
@@ -101,7 +101,7 @@ class TestGroupsOnlyField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Groups Only": swimUser2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Groups Only`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Groups Only"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_groups_only_field_on_save_bad_type_user(helpers):
@@ -112,7 +112,7 @@ class TestGroupsOnlyField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Groups Only"] = swimUser2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User `%s` is not a valid selection for field `Groups Only`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User "%s" is not a valid selection for field "Groups Only"' % (
             theRecord.tracking_id, swimUser2.username)
 
 
@@ -124,7 +124,7 @@ class TestReadOnlyUserGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Read-only User/Groups": swimUser2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Cannot set readonly field \'Read-only User/Groups\'' % pytest.app.acronym
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Cannot set readonly field "Read-only User/Groups"' % pytest.app.acronym
 
     def test_read_only_user_groups_field_on_save(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
@@ -134,7 +134,7 @@ class TestReadOnlyUserGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Read-only User/Groups"] = swimUser2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field \'Read-only User/Groups\'' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Cannot set readonly field "Read-only User/Groups"' % theRecord.tracking_id
 
 
 class TestCreatedByField:
@@ -236,7 +236,7 @@ class TestAllUsersAndGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["All Users and Groups"] = {"name": swimGroup}
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field \'All Users and Groups\' expects one of \'UserGroup\', got \'dict\' instead' % theRecord.tracking_id
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Field "All Users and Groups" expects one of \'UserGroup\', got "dict" instead' % theRecord.tracking_id
 
 
 class TestSelectedGroupsField:
@@ -262,7 +262,7 @@ class TestSelectedGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Selected Groups": swimGroup})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Selected Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Selected Groups"' % (
             pytest.app.acronym, swimGroup.name)
 
     def test_selected_groups_field_wrong_group_on_save(helpers):
@@ -273,7 +273,7 @@ class TestSelectedGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Selected Groups"] = swimGroup
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Selected Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Selected Groups"' % (
             theRecord.tracking_id, swimGroup.name)
 
     def test_selected_groups_field_bad_type_user(helpers):
@@ -283,7 +283,7 @@ class TestSelectedGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Selected Groups": swimUser2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Selected Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Selected Groups"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_selected_groups_field_on_save_bad_type_user(helpers):
@@ -294,7 +294,7 @@ class TestSelectedGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Selected Groups"] = swimUser2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User `%s` is not a valid selection for field `Selected Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User "%s" is not a valid selection for field "Selected Groups"' % (
             theRecord.tracking_id, swimUser2.username)
 
 
@@ -323,7 +323,7 @@ class TestSelectedUsersField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Selected Users": swimUser2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Selected Users`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Selected Users"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_selected_users_field_wrong_user_on_save(helpers):
@@ -334,7 +334,7 @@ class TestSelectedUsersField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Selected Users"] = swimUser2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User `%s` is not a valid selection for field `Selected Users`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User "%s" is not a valid selection for field "Selected Users"' % (
             theRecord.tracking_id, swimUser2.username)
 
     def test_selected_users_field_bad_type_group(helpers):
@@ -344,7 +344,7 @@ class TestSelectedUsersField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Selected Users": swimGroup})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Selected Users`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Selected Users"' % (
             pytest.app.acronym, swimGroup.name)
 
     def test_selected_users_field_on_save_bad_type_group(helpers):
@@ -355,7 +355,7 @@ class TestSelectedUsersField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Selected Users"] = swimGroup
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Selected Users`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Selected Users"' % (
             theRecord.tracking_id, swimGroup.name)
 
 
@@ -382,7 +382,7 @@ class TestSubgroupsOfGroupField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Sub-groups of Group": swimGroup})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Sub-groups of Group`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Sub-groups of Group"' % (
             pytest.app.acronym, swimGroup.name)
 
     def test_sub_groups_of_group_field_parent_group_on_save(helpers):
@@ -393,7 +393,7 @@ class TestSubgroupsOfGroupField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Sub-groups of Group"] = swimGroup
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Sub-groups of Group`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Sub-groups of Group"' % (
             theRecord.tracking_id, swimGroup.name)
 
     def test_sub_groups_of_group_field_other_group(helpers):
@@ -403,7 +403,7 @@ class TestSubgroupsOfGroupField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Sub-groups of Group": swimGroup})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Sub-groups of Group`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Sub-groups of Group"' % (
             pytest.app.acronym, swimGroup.name)
 
     def test_sub_groups_of_group_field_other_group_on_save(helpers):
@@ -414,7 +414,7 @@ class TestSubgroupsOfGroupField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Sub-groups of Group"] = swimGroup
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Sub-groups of Group`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Sub-groups of Group"' % (
             theRecord.tracking_id, swimGroup.name)
 
     def test_sub_groups_of_group_field_user(helpers):
@@ -424,7 +424,7 @@ class TestSubgroupsOfGroupField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Sub-groups of Group": swimUser2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Sub-groups of Group`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Sub-groups of Group"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_sub_groups_of_group_field_user_on_save(helpers):
@@ -435,7 +435,7 @@ class TestSubgroupsOfGroupField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Sub-groups of Group"] = swimUser2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User `%s` is not a valid selection for field `Sub-groups of Group`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User "%s" is not a valid selection for field "Sub-groups of Group"' % (
             theRecord.tracking_id, swimUser2.username)
 
 
@@ -466,7 +466,7 @@ class TestUsersMembersOfGroupField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Users Members of Group": swimUser2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Users Members of Group`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Users Members of Group"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_users_members_of_group_field_not_member_on_save(helpers):
@@ -477,7 +477,7 @@ class TestUsersMembersOfGroupField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Users Members of Group"] = swimUser2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User `%s` is not a valid selection for field `Users Members of Group`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User "%s" is not a valid selection for field "Users Members of Group"' % (
             theRecord.tracking_id, swimUser2.username)
 
     def test_users_members_of_group_field_user_parent_group(helpers):
@@ -486,7 +486,7 @@ class TestUsersMembersOfGroupField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Users Members of Group": swimGroup})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Users Members of Group`' % (pytest.app.acronym, swimGroup.name)
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Users Members of Group"' % (pytest.app.acronym, swimGroup.name)
 
     def test_users_members_of_group_field_parent_group_on_save(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
@@ -495,7 +495,7 @@ class TestUsersMembersOfGroupField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Users Members of Group"] = swimGroup
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Users Members of Group`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Users Members of Group"' % (
             theRecord.tracking_id, swimGroup.name)
 
 
@@ -547,7 +547,7 @@ class TestMultiSelectUsersField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Multi-select User/Groups": [swimGroup]})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Multi-select User/Groups`' % (pytest.app.acronym, swimGroup.name)
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Multi-select User/Groups"' % (pytest.app.acronym, swimGroup.name)
 
     def test_multi_select_users_field_group_on_save(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
@@ -557,7 +557,7 @@ class TestMultiSelectUsersField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Multi-select User/Groups"] = [swimGroup]
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Multi-select User/Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Multi-select User/Groups"' % (
             theRecord.tracking_id, swimGroup.name)
 
     def test_multi_select_users_field_mix_users_groups(helpers):
@@ -569,7 +569,7 @@ class TestMultiSelectUsersField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Multi-select User/Groups": [swimUser2, swimGroup]})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Multi-select User/Groups`' % (pytest.app.acronym, swimGroup.name)
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Multi-select User/Groups"' % (pytest.app.acronym, swimGroup.name)
 
     def test_multi_select_users_field_mix_users_groups_on_save(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
@@ -581,7 +581,7 @@ class TestMultiSelectUsersField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Multi-select User/Groups"] = [swimUser2, swimGroup]
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Multi-select User/Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Multi-select User/Groups"' % (
             theRecord.tracking_id, swimGroup.name)
 
     @pytest.mark.xfail(reason="SPT-6354: This works for the adminuser, but not the others..")
@@ -659,7 +659,7 @@ class TestMultiSelectUsersField:
             **{"Required User/Groups": swimUser, "Multi-select User/Groups": [swimUser, swimUser2]})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Multi-select User/Groups"].select(swimGroup)
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Multi-select User/Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Multi-select User/Groups"' % (
             theRecord.tracking_id, swimGroup.name)
         theRecord.save()
         updatedRecord = pytest.app.records.get(id=theRecord.id)
@@ -709,7 +709,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Multi-select Specific Users and Groups": [swimGroup, swimUser2]})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_multi_select_specific_users_groups_field_user_and_group_invalid_group_create(helpers):
@@ -721,7 +721,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Multi-select Specific Users and Groups": [swimGroup, swimUser2]})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (pytest.app.acronym, swimGroup.name)
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (pytest.app.acronym, swimGroup.name)
 
     def test_multi_select_specific_users_groups_field_invalid_group_create(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
@@ -730,7 +730,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Multi-select Specific Users and Groups": [swimGroup]})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (pytest.app.acronym, swimGroup.name)
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (pytest.app.acronym, swimGroup.name)
 
     def test_multi_select_specific_users_groups_field_invalid_group_subgroup_create(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
@@ -739,7 +739,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Multi-select Specific Users and Groups": [swimGroup]})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (pytest.app.acronym, swimGroup.name)
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (pytest.app.acronym, swimGroup.name)
 
     def test_multi_select_specific_users_groups_field_invalid_user_create(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
@@ -748,7 +748,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Multi-select Specific Users and Groups": [swimUser2]})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_multi_select_specific_users_groups_field_invalid_user_group_member_create(helpers):
@@ -758,7 +758,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Multi-select Specific Users and Groups": [swimUser2]})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_multi_select_specific_users_groups_field_user_save(helpers):
@@ -796,7 +796,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Multi-select Specific Users and Groups"] = [swimGroup]
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (
             theRecord.tracking_id, swimGroup.name)
 
     def test_multi_select_specific_users_groups_field_invalid_group_subgroup_save(helpers):
@@ -807,7 +807,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Multi-select Specific Users and Groups"] = [swimGroup]
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (
             theRecord.tracking_id, swimGroup.name)
 
     def test_multi_select_specific_users_groups_field_invalid_user_save(helpers):
@@ -818,7 +818,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Multi-select Specific Users and Groups"] = [swimUser2]
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (
             theRecord.tracking_id, swimUser2.username)
 
     def test_multi_select_specific_users_groups_field_invalid_user_group_member_save(helpers):
@@ -829,7 +829,7 @@ class TestMultiSelectSpecificUsersAndGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Multi-select Specific Users and Groups"] = [swimUser2]
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User `%s` is not a valid selection for field `Multi-select Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User "%s" is not a valid selection for field "Multi-select Specific Users and Groups"' % (
             theRecord.tracking_id, swimUser2.username)
 
 
@@ -856,7 +856,7 @@ class TestSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Specific Users and Groups": swimGroup})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Specific Users and Groups`' % (pytest.app.acronym, swimGroup.name)
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Specific Users and Groups"' % (pytest.app.acronym, swimGroup.name)
 
     def test_select_specific_users_groups_field_invalid_group_subgroup_create(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
@@ -865,7 +865,7 @@ class TestSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Specific Users and Groups": swimGroup})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group `%s` is not a valid selection for field `Specific Users and Groups`' % (pytest.app.acronym, swimGroup.name)
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: Group "%s" is not a valid selection for field "Specific Users and Groups"' % (pytest.app.acronym, swimGroup.name)
 
     def test_select_specific_users_groups_field_invalid_user_create(helpers):
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
@@ -874,7 +874,7 @@ class TestSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Specific Users and Groups": swimUser2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Specific Users and Groups"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_select_specific_users_groups_field_invalid_user_group_member_create(helpers):
@@ -884,7 +884,7 @@ class TestSelectSpecificUsersAndGroupsField:
         with pytest.raises(exceptions.ValidationError) as excinfo:
             pytest.app.records.create(
                 **{"Required User/Groups": swimUser, "Specific Users and Groups": swimUser2})
-        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User `%s` is not a valid selection for field `Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s - New>. Reason: User "%s" is not a valid selection for field "Specific Users and Groups"' % (
             pytest.app.acronym, swimUser2.username)
 
     def test_select_specific_users_groups_field_user_save(helpers):
@@ -912,7 +912,7 @@ class TestSelectSpecificUsersAndGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Specific Users and Groups"] = swimGroup
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Specific Users and Groups"' % (
             theRecord.tracking_id, swimGroup.name)
 
     def test_select_specific_users_groups_field_invalid_group_subgroup_save(helpers):
@@ -923,7 +923,7 @@ class TestSelectSpecificUsersAndGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Specific Users and Groups"] = swimGroup
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group `%s` is not a valid selection for field `Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: Group "%s" is not a valid selection for field "Specific Users and Groups"' % (
             theRecord.tracking_id, swimGroup.name)
 
     def test_select_specific_users_groups_field_invalid_user_save(helpers):
@@ -934,7 +934,7 @@ class TestSelectSpecificUsersAndGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Specific Users and Groups"] = swimUser2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User `%s` is not a valid selection for field `Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User "%s" is not a valid selection for field "Specific Users and Groups"' % (
             theRecord.tracking_id, swimUser2.username)
 
     def test_select_specific_users_groups_field_invalid_user_group_member_save(helpers):
@@ -945,5 +945,5 @@ class TestSelectSpecificUsersAndGroupsField:
             **{"Required User/Groups": swimUser})
         with pytest.raises(exceptions.ValidationError) as excinfo:
             theRecord["Specific Users and Groups"] = swimUser2
-        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User `%s` is not a valid selection for field `Specific Users and Groups`' % (
+        assert str(excinfo.value) == 'Validation failed for <Record: %s>. Reason: User "%s" is not a valid selection for field "Specific Users and Groups"' % (
             theRecord.tracking_id, swimUser2.username)

--- a/swimlane/core/adapters/helper.py
+++ b/swimlane/core/adapters/helper.py
@@ -52,7 +52,7 @@ class HelperAdapter(SwimlaneResolver):
         validate_str(message, 'message')
         
         if not isinstance(rich_text, bool):
-            raise ValueError("rich_text must be a boolean value.")
+            raise ValueError('rich_text must be a boolean value.')
 
         self._swimlane.request(
             'post',

--- a/swimlane/core/adapters/record.py
+++ b/swimlane/core/adapters/record.py
@@ -283,7 +283,7 @@ class RecordAdapter(AppResolver):
             raise ValueError('Must provide "values" as keyword argument')
 
         if not isinstance(values, dict):
-            raise ValueError("values parameter must be dict of {'field_name': 'update_value'} pairs")
+            raise ValueError('values parameter must be dict of {"field_name": "update_value"} pairs')
 
         _type = validate_filters_or_records_or_ids(filters_or_records_or_ids)
 
@@ -329,7 +329,7 @@ class RecordAdapter(AppResolver):
             # Lookup target field
             modification_field = record_stub.get_field(field_name)
             if not modification_field.bulk_modify_support:
-                raise ValueError("Field '{}' of Type '{}', is not supported for bulk modify".format(
+                raise ValueError('Field "{}" of Type "{}", is not supported for bulk modify'.format(
                     field_name,
                     modification_field.__class__.__name__
                 ))
@@ -455,7 +455,7 @@ def validate_filters_or_records_or_ids(filters_or_records_or_ids):
         elif _type is str:
             types_dict["str"] = types_dict["tuple"] + 1
         else:
-            raise ValueError("Expected filter tuple, Record, or string, received {0}".format(_type))
+            raise ValueError('Expected filter tuple, Record, or string, received {0}'.format(_type))
 
     if types_dict["tuple"] > 0 and (types_dict["record"] > 0 or types_dict["str"] > 0):
         raise ValueError('Cannot mix filter tuples with records or ids')

--- a/swimlane/core/cache.py
+++ b/swimlane/core/cache.py
@@ -73,7 +73,7 @@ class ResourcesCache(object):
     def cache(self, resource):
         """Insert a resource instance into appropriate resource cache"""
         if not isinstance(resource, APIResource):
-            raise TypeError('Cannot cache `{!r}`, can only cache APIResource instances'.format(resource))
+            raise TypeError('Cannot cache "{!r}", can only cache APIResource instances'.format(resource))
 
         # Disable inserts to cache when disabled
         if self.__cache_max_size == 0:
@@ -84,7 +84,7 @@ class ResourcesCache(object):
             cache_index_keys = resource.get_cache_index_keys().items()
         except NotImplementedError:
             logger.warning(
-                'Not caching `{!r}`, resource did not provide all necessary cache details'.format(resource)
+                'Not caching "{!r}", resource did not provide all necessary cache details'.format(resource)
             )
         else:
             resource_type = type(resource)
@@ -94,7 +94,7 @@ class ResourcesCache(object):
 
             self.__caches[resource_type][cache_internal_key] = resource
 
-            logger.debug('Cached `{!r}`'.format(resource))
+            logger.debug('Cached "{!r}"'.format(resource))
 
     def clear(self, *resource_types):
         """Clear cache for each provided APIResource class, or all resources if no classes are provided"""
@@ -122,10 +122,10 @@ def get_cache_index_key(resource):
         key = tuple(resource)
 
     if len(key) != 3:
-        raise TypeError('Cache key must be tuple of (class, key, value), got `{!r}` instead'.format(key))
+        raise TypeError('Cache key must be tuple of (class, key, value), got "{!r}" instead'.format(key))
 
     if not issubclass(key[0], APIResource):
-        raise TypeError('First value of cache key must be a subclass of APIResource, got `{!r}` instead'.format(key[0]))
+        raise TypeError('First value of cache key must be a subclass of APIResource, got "{!r}" instead'.format(key[0]))
 
     return key
 
@@ -153,9 +153,9 @@ def check_cache(resource_type):
                 try:
                     cached_record = adapter._swimlane.resources_cache[index_key]
                 except KeyError:
-                    logger.debug('Cache miss: `{!r}`'.format(index_key))
+                    logger.debug('Cache miss: "{!r}"'.format(index_key))
                 else:
-                    logger.debug('Cache hit: `{!r}`'.format(cached_record))
+                    logger.debug('Cache hit: "{!r}"'.format(cached_record))
                     return cached_record
 
             # Fallback to default function call

--- a/swimlane/core/fields/base/field.py
+++ b/swimlane/core/fields/base/field.py
@@ -109,10 +109,10 @@ class Field(SwimlaneResolver):
     def validate_value(self, value):
         """Validate value is an acceptable type during set_python operation"""
         if self.readonly and not self._swimlane._write_to_read_only:
-            raise ValidationError(self.record, "Cannot set readonly field '{}'".format(self.name))
+            raise ValidationError(self.record, 'Cannot set readonly field "{}"'.format(self.name))
         if value not in (None, self._unset):
             if self.supported_types and not isinstance(value, tuple(self.supported_types)):
-                raise ValidationError(self.record, "Field '{}' expects one of {}, got '{}' instead".format(
+                raise ValidationError(self.record, 'Field "{}" expects one of {}, got "{}" instead'.format(
                     self.name,
                     ', '.join([repr(t.__name__) for t in self.supported_types]),
                     type(value).__name__)

--- a/swimlane/core/fields/comment.py
+++ b/swimlane/core/fields/comment.py
@@ -11,7 +11,7 @@ class CommentCursor(FieldCursor):
         """Add new comment to record comment field"""
         message = str(message)
         if not isinstance(rich_text, bool):
-            raise ValueError("rich_text must be a boolean value.")
+            raise ValueError('rich_text must be a boolean value.')
 
         sw_repr = {
             '$type': 'Core.Models.Record.Comments, Core',

--- a/swimlane/core/fields/list.py
+++ b/swimlane/core/fields/list.py
@@ -28,14 +28,14 @@ class _ListFieldCursor(FieldCursor):
             if len(target) < min_items:
                 raise ValidationError(
                     self._record,
-                    "Field '{}' must have a minimum of {} item(s)".format(self._field.name, min_items)
+                    'Field "{}" must have a minimum of {} item(s)'.format(self._field.name, min_items)
                 )
 
         if max_items is not None:
             if len(target) > max_items:
                 raise ValidationError(
                     self._record,
-                    "Field '{}' can only have a maximum of {} item(s)".format(self._field.name, max_items)
+                    'Field "{}" can only have a maximum of {} item(s)'.format(self._field.name, max_items)
                 )
 
         # Individual item validation
@@ -82,7 +82,7 @@ class _ListFieldCursor(FieldCursor):
             return wrapper
         except AttributeError:
             # Raise separate AttributeError with correct class reference instead of list
-            raise AttributeError("{} object has no attribute {}".format(self.__class__, item))
+            raise AttributeError('{} object has no attribute {}'.format(self.__class__, item))
 
 
 class TextListFieldCursor(_ListFieldCursor):
@@ -93,7 +93,7 @@ class TextListFieldCursor(_ListFieldCursor):
         if not isinstance(item, six.string_types):
             raise ValidationError(
                 self._record,
-                "Text list field items must be strings, not '{}'".format(item.__class__)
+                'Text list field items must be strings, not "{}"'.format(item.__class__)
             )
 
         words = item.split(' ')
@@ -108,7 +108,7 @@ class TextListFieldCursor(_ListFieldCursor):
                     if len(words) > item_max_length:
                         raise ValidationError(
                             self._record,
-                            "Field '{}' items cannot contain more than {} words".format(
+                            'Field "{}" items cannot contain more than {} words'.format(
                                 self._field.name,
                                 item_max_length
                             )
@@ -117,7 +117,7 @@ class TextListFieldCursor(_ListFieldCursor):
                     if len(words) < item_min_length:
                         raise ValidationError(
                             self._record,
-                            "Field '{}' items must contain at least {} words".format(
+                            'Field "{}" items must contain at least {} words'.format(
                                 self._field.name,
                                 item_min_length
                             )
@@ -129,7 +129,7 @@ class TextListFieldCursor(_ListFieldCursor):
                     if len(item) > item_max_length:
                         raise ValidationError(
                             self._record,
-                            "Field '{}' items cannot contain more than {} characters".format(
+                            'Field "{}" items cannot contain more than {} characters'.format(
                                 self._field.name,
                                 item_max_length
                             )
@@ -138,7 +138,7 @@ class TextListFieldCursor(_ListFieldCursor):
                     if len(item) < item_min_length:
                         raise ValidationError(
                             self._record,
-                            "Field '{}' items must contain at least {} characters".format(
+                            'Field "{}" items must contain at least {} characters'.format(
                                 self._field.name,
                                 item_min_length
                             )
@@ -152,7 +152,7 @@ class NumericListFieldCursor(_ListFieldCursor):
         if not isinstance(item, Number):
             raise ValidationError(
                 self._record,
-                "Numeric list field items must be numbers, not '{}'".format(item.__class__)
+                'Numeric list field items must be numbers, not "{}"'.format(item.__class__)
             )
 
         # range restrictions
@@ -163,7 +163,7 @@ class NumericListFieldCursor(_ListFieldCursor):
             if item > item_max:
                 raise ValidationError(
                     self._record,
-                    "Field '{}' items cannot be greater than {}".format(
+                    'Field "{}" items cannot be greater than {}'.format(
                         self._field.name,
                         item_max
                     )
@@ -173,7 +173,7 @@ class NumericListFieldCursor(_ListFieldCursor):
             if item < item_min:
                 raise ValidationError(
                     self._record,
-                    "Field '{}' items cannot be less than {}".format(
+                    'Field "{}" items cannot be less than {}'.format(
                         self._field.name,
                         item_min
                     )
@@ -226,7 +226,7 @@ class ListField(CursorField):
         if not isinstance(value, (list, type(None))):
             raise ValidationError(
                 self.record,
-                "Field '{}' must be set to a list, not '{}'".format(
+                'Field "{}" must be set to a list, not "{}"'.format(
                     self.name,
                     value.__class__
                 )

--- a/swimlane/core/fields/number.py
+++ b/swimlane/core/fields/number.py
@@ -24,14 +24,14 @@ class NumberField(Field):
 
         if value is not None:
             if self.min is not None and value < self.min:
-                raise ValidationError(self.record, "Field '{}' minimum value '{}', received '{}'".format(
+                raise ValidationError(self.record, 'Field "{}" minimum value "{}", received "{}"'.format(
                     self.name,
                     self.min,
                     value
                 ))
 
             if self.max is not None and value > self.max:
-                raise ValidationError(self.record, "Field '{}' maximum value '{}', received '{}'".format(
+                raise ValidationError(self.record, 'Field "{}" maximum value "{}", received "{}"'.format(
                     self.name,
                     self.max,
                     value

--- a/swimlane/core/fields/reference.py
+++ b/swimlane/core/fields/reference.py
@@ -28,7 +28,7 @@ class ReferenceCursor(FieldCursor):
                 self._elements[record_id] = records_get
                 return records_get
             except SwimlaneHTTP400Error:
-                logger.debug("Received 400 response retrieving record '{}', ignoring assumed orphaned record")
+                logger.debug('Received 400 response retrieving record "{}", ignoring assumed orphaned record')
         else:
             return record
 
@@ -40,7 +40,7 @@ class ReferenceCursor(FieldCursor):
                     self._elements[record_id] = records_get
                     yield records_get
                 except SwimlaneHTTP400Error:
-                    logger.debug("Received 400 response retrieving record '{}', ignoring assumed orphaned record")
+                    logger.debug('Received 400 response retrieving record "{}", ignoring assumed orphaned record')
             else:
                 yield record
 
@@ -83,7 +83,7 @@ class ReferenceField(CursorField):
             if value.app != self.target_app:
                 raise ValidationError(
                     self.record,
-                    "Reference field '{}' has target app '{}', cannot reference record '{}' from app '{}'".format(
+                    'Reference field "{}" has target app "{}", cannot reference record "{}" from app "{}"'.format(
                         self.name,
                         self.target_app,
                         value,

--- a/swimlane/core/fields/usergroup.py
+++ b/swimlane/core/fields/usergroup.py
@@ -70,7 +70,7 @@ class UserGroupField(MultiSelectField):
 
         raise ValidationError(
             self.record,
-            'User `{}` is not a valid selection for field `{}`'.format(
+            'User "{}" is not a valid selection for field "{}"'.format(
                 user,
                 self.name
             )
@@ -96,7 +96,7 @@ class UserGroupField(MultiSelectField):
 
         raise ValidationError(
             self.record,
-            'Group `{}` is not a valid selection for field `{}`'.format(
+            'Group "{}" is not a valid selection for field "{}"'.format(
                 group,
                 self.name
             )
@@ -127,7 +127,7 @@ class UserGroupField(MultiSelectField):
         if value is not None:
             if not isinstance(value, UserGroup):
                     raise TypeError(
-                        'Expected UserGroup, received `{}` instead'.format(value))
+                        'Expected UserGroup, received "{}" instead'.format(value))
             value = value.as_usergroup_selection()
 
         return value

--- a/swimlane/core/resources/app.py
+++ b/swimlane/core/resources/app.py
@@ -79,7 +79,7 @@ class App(APIResource):
 
     def __lt__(self, other):
         if not isinstance(other, self.__class__):
-            raise TypeError("Comparisons not supported between instances of '{}' and '{}'".format(
+            raise TypeError('Comparisons not supported between instances of "{}" and "{}"'.format(
                 other.__class__.__name__,
                 self.__class__.__name__
             ))

--- a/swimlane/core/resources/record.py
+++ b/swimlane/core/resources/record.py
@@ -39,7 +39,7 @@ class Record(APIResource):
         else:
             record_app_id = raw['applicationId']
             if record_app_id != app.id:
-                raise ValueError('Record applicationId `{}` does not match source app id `{}`'.format(
+                raise ValueError('Record applicationId "{}" does not match source app id "{}"'.format(
                     record_app_id,
                     app.id
                 ))
@@ -104,7 +104,7 @@ class Record(APIResource):
 
     def __lt__(self, other):
         if not isinstance(other, self.__class__):
-            raise TypeError("Comparisons not supported between instances of '{}' and '{}'".format(
+            raise TypeError('Comparisons not supported between instances of "{}" and "{}"'.format(
                 other.__class__.__name__,
                 self.__class__.__name__
             ))
@@ -331,7 +331,7 @@ class Record(APIResource):
         for usergroup in usergroups:
             if not isinstance(usergroup, UserGroup):
                 raise TypeError(
-                    'Expected UserGroup, received `{}` instead'.format(usergroup))
+                    'Expected UserGroup, received "{}" instead'.format(usergroup))
 
             selection = usergroup.as_usergroup_selection()
             if selection not in allowed:
@@ -369,12 +369,12 @@ class Record(APIResource):
             for usergroup in usergroups:
                 if not isinstance(usergroup, UserGroup):
                     raise TypeError(
-                        'Expected UserGroup, received `{}` instead'.format(usergroup))
+                        'Expected UserGroup, received "{}" instead'.format(usergroup))
                 try:
                     allowed.remove(usergroup.as_usergroup_selection())
                 except ValueError:
                     raise ValueError(
-                        'UserGroup `{}` not in record `{}` restriction list'.format(usergroup, self))
+                        'UserGroup "{}" not in record "{}" restriction list'.format(usergroup, self))
         else:
             allowed = []
 

--- a/swimlane/core/resources/usergroup.py
+++ b/swimlane/core/resources/usergroup.py
@@ -39,7 +39,7 @@ class UserGroup(APIResource):
 
     def __lt__(self, other):
         if not isinstance(other, UserGroup):
-            raise TypeError("Comparisons not supported between instances of '{}' and '{}'".format(
+            raise TypeError('Comparisons not supported between instances of "{}" and "{}"'.format(
                 other.__class__.__name__,
                 self.__class__.__name__
             ))

--- a/swimlane/utils/__init__.py
+++ b/swimlane/utils/__init__.py
@@ -129,4 +129,4 @@ def validate_type(field, value):
             ) if len(field.supported_types) > 0 else False
 
             if wrong_type:
-                raise ValueError("Value must be one of {}".format(", ".join([str(f) for f in field.supported_types])))
+                raise ValueError('Value must be one of {}'.format(", ".join([str(f) for f in field.supported_types])))


### PR DESCRIPTION
For error messages, we are using multiple types of quotes for quoting substrings within the string.
Examples: 
- `raise ValueError('The value provided for the key "{0}" cannot be empty or None'.format(key))`
- `raise ValueError("Field '{}' of Type '{}', is not supported for bulk modify".format()`

We should standardize on a format and use the first example as our standard.
Examples:
- `raise ValueError('This is an error')`
- `raise ValueError('This is an error with the following message: "{}"'.format('message')`