### PR TITLE
SPT-6533: userGroup Field with value set to members of a group does not allow adding users to the field.

### DIFF
--- a/swimlane/core/fields/usergroup.py
+++ b/swimlane/core/fields/usergroup.py
@@ -55,6 +55,10 @@ class UserGroupField(MultiSelectField):
 
     def _validate_user(self, user):
         """Validate a User instance against allowed user IDs or membership in a group"""
+        if user._raw['groups'] == []:
+           result = self._swimlane.request('get', "user/{0}".format(user.id))
+           user._raw['groups'] = result.json()['groups']
+
         # All users allowed
         if self._show_all_users:
             return


### PR DESCRIPTION
# Devex Change Request

## Change Comments

I updated the validation process because I need to get the entire user to retrieve the groups data.

## Solution description

I added a line to verify if the user has the groups field if not we are going to get all the user data to verify it.

Evidences:
_**Current:**_
https://user-images.githubusercontent.com/100230626/219811229-08aa0c5e-862b-44bc-9807-082b8e1e3ee9.mov


_**Fixed:**_
https://user-images.githubusercontent.com/100230626/219811422-06ce66dd-f4de-4e24-a391-8cc0337befc9.mov

Tests:

![Screenshot 2023-02-20 at 10 38 48 AM](https://user-images.githubusercontent.com/100230626/220161193-ee7d3ac0-a853-4fd9-a7b0-66c03a1e9622.png)


## Checklist

<!-- Strike out any steps that do not apply -->

_**PR is ready for code review and approval when each box is checked.**_

_All steps are required, when applicable. ~Strikeout~ formatting indicates a step is not applicable to this change set._

- [x] Ticket referenced in PR title (ex. _SPT-XXX: Short summary of change_)