### PR TITLE
fix: All attributes for an element of the history field should report not being editable.

### DIFF
--- a/functional_tests/driver_tests/test_history_fields.py
+++ b/functional_tests/driver_tests/test_history_fields.py
@@ -45,23 +45,21 @@ class TestHistoryField:
             theRecord["history"][1].version = "400"
         assert str(excinfo.value) == "can't set attribute"
 
-    @pytest.mark.xfail(reason="SPT-6359: No attributes should be editable.")
     def test_history_field_edit_revision_number(helpers):
         theRecord = pytest.app.records.create(**{"Text": "Create"})
         theRecord["Text"] = "First Edit"
         theRecord.save()
-        # with pytest.raises(AttributeError) as excinfo:
-        theRecord["history"][1].revision_number = "400"
-        # assert str(excinfo.value) == "can't set attribute"
+        with pytest.raises(AttributeError) as excinfo:
+            theRecord["history"][1].revision_number = "400"
+        assert str(excinfo.value) == "can't set attribute"
 
-    @pytest.mark.xfail(reason="SPT-6359: No attributes should be editable.")
     def test_history_field_edit_modified_date(helpers):
         theRecord = pytest.app.records.create(**{"Text": "Create"})
         theRecord["Text"] = "First Edit"
         theRecord.save()
-        # with pytest.raises(AttributeError) as excinfo:
-        theRecord["history"][1].modified_date = pendulum.now()
-        # assert str(excinfo.value) == "can't set attribute"
+        with pytest.raises(AttributeError) as excinfo:
+            theRecord["history"][1].modified_date = pendulum.now()
+        assert str(excinfo.value) == "can't set attribute"
 
     def test_history_field_edit_app_version(helpers):
         theRecord = pytest.app.records.create(**{"Text": "Create"})
@@ -71,21 +69,19 @@ class TestHistoryField:
             theRecord["history"][1].app_version = 123
         assert str(excinfo.value) == "can't set attribute"
 
-    @pytest.mark.xfail(reason="SPT-6359: No attributes should be editable.")
     def test_history_field_edit_app_revision_number(helpers):
         theRecord = pytest.app.records.create(**{"Text": "Create"})
         theRecord["Text"] = "First Edit"
         theRecord.save()
-        # with pytest.raises(AttributeError) as excinfo:
-        theRecord["history"][1].app_revision_number = 123
-        # assert str(excinfo.value) == "can't set attribute"
+        with pytest.raises(AttributeError) as excinfo:
+            theRecord["history"][1].app_revision_number = 123
+        assert str(excinfo.value) == "can't set attribute"
 
-    @pytest.mark.xfail(reason="SPT-6359: No attributes should be editable.")
     def test_history_field_edit_user(helpers):
         theRecord = pytest.app.records.create(**{"Text": "Create"})
         swimUser = pytest.swimlane_instance.users.get(display_name="admin")
         theRecord["Text"] = "First Edit"
         theRecord.save()
-        # with pytest.raises(AttributeError) as excinfo:
-        theRecord["history"][1].user = swimUser
-        # assert str(excinfo.value) == "can't set attribute"
+        with pytest.raises(AttributeError) as excinfo:
+            theRecord["history"][1].user = swimUser
+        assert str(excinfo.value) == "can't set attribute"

--- a/swimlane/core/resources/record_revision.py
+++ b/swimlane/core/resources/record_revision.py
@@ -19,7 +19,7 @@ class RecordRevision(RevisionBase):
         self.__app_version = None
         self._app = app
 
-        self.app_revision_number = self._raw_version['applicationRevision']
+        self._app_revision_number = self._raw_version['applicationRevision']
 
     @property
     def app_version(self):
@@ -34,3 +34,11 @@ class RecordRevision(RevisionBase):
         if not self._version:
             self._version = Record(self.app_version, self._raw_version)
         return self._version
+
+    @property
+    def app_revision_number(self):
+        return self._app_revision_number
+    
+    @app_revision_number.setter
+    def app_revision_number(self, value):
+        raise AttributeError("can't set attribute")

--- a/swimlane/core/resources/revision_base.py
+++ b/swimlane/core/resources/revision_base.py
@@ -19,12 +19,12 @@ class RevisionBase(APIResource):
     def __init__(self, swimlane, raw):
         super(RevisionBase, self).__init__(swimlane, raw)
 
-        self.modified_date = pendulum.parse(self._raw['modifiedDate'])
-        self.revision_number = self._raw['revisionNumber']
+        self._modified_date = pendulum.parse(self._raw['modifiedDate'])
+        self._revision_number = self._raw['revisionNumber']
         self.status = self._raw['status']
 
         # UserGroupSelection, can't set as User without additional lookup
-        self.user = UserGroup(self._swimlane, self._raw['userId'])
+        self._user = UserGroup(self._swimlane, self._raw['userId'])
 
         self._raw_version = self._raw['version']
         self._version = None
@@ -43,3 +43,27 @@ class RevisionBase(APIResource):
             'revisionNumber': self.revision_number,
             'user': self.user.for_json()
         }
+    
+    @property
+    def revision_number(self):
+        return self._revision_number
+    
+    @revision_number.setter
+    def revision_number(self, value):
+        raise AttributeError("can't set attribute")
+
+    @property
+    def modified_date(self):
+        return self._modified_date
+    
+    @modified_date.setter
+    def modified_date(self, value):
+        raise AttributeError("can't set attribute")
+    
+    @property
+    def user(self):
+        return self._user
+    
+    @user.setter
+    def user(self, value):
+        raise AttributeError("can't set attribute")


### PR DESCRIPTION
# Devex Change Request

## Change Comments

I updated the pyDriver to throw an error when you try to set an not editable field.

## Solution description

I updated the pythonDriver to throw an exception when you try to edit an not editable field.

Evidences:
_**Current:**_
https://user-images.githubusercontent.com/100230626/220434261-0e4db935-ba07-4a80-9985-47832b49a619.mov

_**Fixed:**_
https://user-images.githubusercontent.com/100230626/220433846-df85ed4d-2530-4799-bb49-5a727b2586c7.mov

Tests:
_**Current:**_
![Screenshot 2023-02-21 at 12 57 58 PM](https://user-images.githubusercontent.com/100230626/220434650-1ea63cb2-67f6-448f-97aa-12bfe65cc9a5.png)

_**Fixed:**_
![Screenshot 2023-02-21 at 12 28 03 PM](https://user-images.githubusercontent.com/100230626/220434441-38658fd8-a699-41d4-946b-c60b31ca305f.png)


## Checklist

<!-- Strike out any steps that do not apply -->

_**PR is ready for code review and approval when each box is checked.**_

_All steps are required, when applicable. ~Strikeout~ formatting indicates a step is not applicable to this change set._

- [x] Ticket referenced in PR title (ex. _SPT-XXX: Short summary of change_)