### PR TITLE
SPT-7929: Bulk modify of text or numeric list does not remove the item if it is the only one left

### DIFF
--- a/functional_tests/driver_tests/test_records_bulk_adaptor.py
+++ b/functional_tests/driver_tests/test_records_bulk_adaptor.py
@@ -766,7 +766,6 @@ class TestRecordAdaptorBulkModifyRemove:
         assert len(pytest.app.records.search(
             ('Multi-select', 'contains', ["three"]))) == 0
 
-    @pytest.mark.xfail(reason="SPT-7929: IS the bulk modify not removing text list item if it is the last item")
     def test_record_bulk_modify_remove_text_list(helpers):
         pytest.app.records.bulk_create({'Text List': ['bob']}, {'Text List': ['bob', 'goodbye']}, {
                                        'Text List': ['bob']}, {'Text List': ['bob', 'goodbye', 'fred']})
@@ -776,7 +775,6 @@ class TestRecordAdaptorBulkModifyRemove:
         assert len(pytest.app.records.search(
             ('Text List', 'contains', ["bob"]))) == 0
 
-    @pytest.mark.xfail(reason="SPT-7929: IS the bulk modify not removing numeric list item if it is the last item")
     def test_record_bulk_modify_remove_numeric_list(helpers):
         pytest.app.records.bulk_create({'Numeric List': [123]}, {'Numeric List': [123, 456]}, {
                                        'Numeric List': [456, 123]}, {'Numeric List': [123, 456, 789]})


### PR DESCRIPTION
Removed `xfail` from tests:
- `test_record_bulk_modify_remove_text_list`
- `test_record_bulk_modify_remove_numeric_list`

Tests should pass once [this PR](https://github.com/swimlane/swimlane/pull/2410) is merged.