### PR TITLE
SPT-6525: Python Driver Should Evaluate an Empty String to None

### DIFF
--- a/swimlane/core/resources/report.py
+++ b/swimlane/core/resources/report.py
@@ -185,7 +185,6 @@ class Report(APIResource, PaginatedCursor):
     def get_default_value(self, value, field_type):
         if(value == '' and field_type == 'text'):
             value = None
-        print('Value', value)
         return value
 
     def get_field_list_type(self, field_type):

--- a/swimlane/core/resources/report.py
+++ b/swimlane/core/resources/report.py
@@ -168,6 +168,7 @@ class Report(APIResource, PaginatedCursor):
     def parse_field_value(self, field, value):
         if isinstance(field, ListField):
             type = self.get_field_list_type(field.input_type)
+            value = self.get_default_value(value, field.input_type)
         if isinstance(field, ListField) and not isinstance(value, list) and value is not None:
             self.validate_type(value, type, field.input_type)
             return [value]
@@ -180,6 +181,12 @@ class Report(APIResource, PaginatedCursor):
             type_name = type
         if not isinstance(value, type):
             raise TypeError('Field must be a {}.'.format(type_name))
+        
+    def get_default_value(self, value, field_type):
+        if(value == '' and field_type == 'text'):
+            value = None
+        print('Value', value)
+        return value
 
     def get_field_list_type(self, field_type):
         if field_type == 'text':


### PR DESCRIPTION
# Devex Change Request

## Change Comments

I fixed the search function to accept '' as a default value for text list field.

## Solution description

I repaired the text list field search because now we accept None or '' as a default value when we are looking for a record.

Evidences:
_**Current:**_
https://user-images.githubusercontent.com/100230626/221235423-dca4b3d4-fed6-4389-aced-faf68e56dbd7.mov


_**Fixed:**_
https://user-images.githubusercontent.com/100230626/221030504-0e5d3388-a227-45ff-98a6-273cd57fdb01.mov


Tests:
![Screenshot 2023-02-23 at 3 09 53 PM](https://user-images.githubusercontent.com/100230626/221030907-3ccd11d2-357e-4130-8c6c-54203cc1b0cd.png)

## Checklist

<!-- Strike out any steps that do not apply -->

_**PR is ready for code review and approval when each box is checked.**_

_All steps are required, when applicable. ~Strikeout~ formatting indicates a step is not applicable to this change set._

- [x] Ticket referenced in PR title (ex. _SPT-XXX: Short summary of change_)