### PR TITLE
SPT-17728: Add Support for "or" operator Record Search Feature.

### DIFF
--- a/swimlane/core/adapters/record.py
+++ b/swimlane/core/adapters/record.py
@@ -8,6 +8,7 @@ from swimlane.core.resources.report import Report
 from swimlane.utils import random_string, one_of_keyword_only, validate_type
 from swimlane.utils.version import requires_swimlane_version
 
+ALLOWED_OPERATORS = ['Or', 'And']
 
 class RecordAdapter(AppResolver):
     """Handles retrieval and creation of Swimlane Record resources"""
@@ -44,7 +45,7 @@ class RecordAdapter(AppResolver):
             response = self._swimlane.request('get', "app/{0}/record/tracking/{1}".format(self._app.id, value))
             return Record(self._app, response.json())
 
-    def search(self, *filters, **kwargs):
+    def search(self, *filters, filter_type = 'And', **kwargs):
         """Shortcut to generate a new temporary search report using provided filters and return the resulting records
 
         Args:
@@ -118,9 +119,17 @@ class RecordAdapter(AppResolver):
         columns = kwargs.pop('columns', None)
         if columns:
             report.set_columns(*columns)
+        
+        operator = filter_type.capitalize()
+        self.validateOperator(operator)
+        report.filter_type(operator)     
 
         return list(report)
-
+    
+    def validateOperator(self, operator):
+        if operator not in ALLOWED_OPERATORS:
+            raise ValueError('filter_type value not allowed')
+  
     def create(self, **fields):
         """Create and return a new record in associated app and return the newly created Record instance
 

--- a/swimlane/core/adapters/record.py
+++ b/swimlane/core/adapters/record.py
@@ -8,8 +8,6 @@ from swimlane.core.resources.report import Report
 from swimlane.utils import random_string, one_of_keyword_only, validate_type
 from swimlane.utils.version import requires_swimlane_version
 
-ALLOWED_OPERATORS = ['Or', 'And']
-
 class RecordAdapter(AppResolver):
     """Handles retrieval and creation of Swimlane Record resources"""
 
@@ -120,15 +118,10 @@ class RecordAdapter(AppResolver):
         if columns:
             report.set_columns(*columns)
         
-        operator = filter_type.capitalize()
-        self.validateOperator(operator)
-        report.filter_type(operator)     
+        report.filter_type(filter_type)     
 
         return list(report)
     
-    def validateOperator(self, operator):
-        if operator not in ALLOWED_OPERATORS:
-            raise ValueError('filter_type value not allowed')
   
     def create(self, **fields):
         """Create and return a new record in associated app and return the newly created Record instance

--- a/swimlane/core/resources/report.py
+++ b/swimlane/core/resources/report.py
@@ -1,4 +1,6 @@
 import pendulum
+import json 
+
 
 from swimlane.core.cursor import PaginatedCursor
 from swimlane.core.fields.list import ListField
@@ -82,6 +84,9 @@ class Report(APIResource, PaginatedCursor):
         for field_id in self._app._fields_by_id.keys():
             self._raw['columns'].append(field_id)
 
+    def filter_type(self, field_type):
+        self.filter_type = field_type
+
     def __str__(self):
         return self.name
 
@@ -90,6 +95,7 @@ class Report(APIResource, PaginatedCursor):
 
         body['pageSize'] = self.page_size
         body['offset'] = page
+        body['filterType'] = self.filter_type
         body['keywords'] = ', '.join(self.keywords)
 
         response = self._swimlane.request('post', 'search', json=body)

--- a/swimlane/core/resources/report.py
+++ b/swimlane/core/resources/report.py
@@ -9,6 +9,8 @@ from swimlane.core.resources.record import Record, record_factory
 from swimlane.core.search import CONTAINS, EQ, EXCLUDES, NOT_EQ, LT, GT, LTE, GTE, ASC, DESC
 from swimlane.utils import validate_type
 
+ALLOWED_OPERATORS = ['Or', 'And']
+
 
 class Report(APIResource, PaginatedCursor):
     """A report class used for searching
@@ -84,8 +86,14 @@ class Report(APIResource, PaginatedCursor):
         for field_id in self._app._fields_by_id.keys():
             self._raw['columns'].append(field_id)
 
-    def filter_type(self, field_type):
-        self.filter_type = field_type
+    def filter_type(self, filter_type):
+        filter_type = filter_type.capitalize()
+        self.validateOperator(filter_type)
+        self.filter_type = filter_type
+
+    def validateOperator(self, operator):
+        if operator not in ALLOWED_OPERATORS:
+            raise ValueError('filter_type value not allowed')
 
     def __str__(self):
         return self.name

--- a/swimlane/core/resources/report.py
+++ b/swimlane/core/resources/report.py
@@ -95,7 +95,8 @@ class Report(APIResource, PaginatedCursor):
 
         body['pageSize'] = self.page_size
         body['offset'] = page
-        body['filterType'] = self.filter_type
+        if(type(self.filter_type) is str):
+            body['filterType'] = self.filter_type
         body['keywords'] = ', '.join(self.keywords)
 
         response = self._swimlane.request('post', 'search', json=body)


### PR DESCRIPTION
# Devex Change Request

## Change Comments

I updated the library to support 'or' operator on record search.

## Solution description

I modified the pydriver to support 'or' conditions when you try to search records, but by default the operator is 'and'.

Evidences:
_**Current:**_
With 'or' and kwarg:
<img width="1397" alt="Screenshot 2023-03-27 at 3 20 23 PM" src="https://user-images.githubusercontent.com/100230626/228069364-aaa946d5-df96-4d8b-bbfe-c3a691b5082f.png">

With kwarg:
<img width="1397" alt="Screenshot 2023-03-27 at 3 21 19 PM" src="https://user-images.githubusercontent.com/100230626/228069516-1e8e7768-15ca-4f07-9a81-a1255c563730.png">

With one filter:
<img width="1397" alt="Screenshot 2023-03-27 at 3 21 38 PM" src="https://user-images.githubusercontent.com/100230626/228069568-5bd4fa3e-b2bc-4697-95e2-bdfc3f3f4ec5.png">

Testing:
![Screenshot 2023-03-27 at 3 09 39 PM](https://user-images.githubusercontent.com/100230626/228067278-5b9a6797-9125-4e9f-8e14-d3944679300d.png)


_**Fixed:**_
With 'or' and kwarg:
<img width="1397" alt="Screenshot 2023-03-27 at 3 23 20 PM" src="https://user-images.githubusercontent.com/100230626/228069903-d9b77e2a-b469-4030-9c72-bba951e9a112.png">


With kwarg:
<img width="1617" alt="Screenshot 2023-03-27 at 11 50 51 AM" src="https://user-images.githubusercontent.com/100230626/228063547-7ad079ef-5620-41d8-81a2-b653769c3481.png">

With one filter:
<img width="1617" alt="Screenshot 2023-03-27 at 11 51 24 AM" src="https://user-images.githubusercontent.com/100230626/228063689-1f99dbba-2476-40fd-92c9-80a2a3924242.png">

With default operator:
<img width="1617" alt="Screenshot 2023-03-27 at 11 51 06 AM" src="https://user-images.githubusercontent.com/100230626/228063603-1079c601-487f-4ef0-9148-6274dc9c50d2.png">

Testing:
![Screenshot 2023-03-27 at 2 30 07 PM](https://user-images.githubusercontent.com/100230626/228064448-65afcd45-3b1a-46db-992e-2177fcc58ebf.png)

Validate operator:
<img width="1397" alt="Screenshot 2023-03-27 at 3 50 05 PM" src="https://user-images.githubusercontent.com/100230626/228074972-d6954f64-8435-42ce-b587-83ad12f44bf7.png">

## Checklist

<!-- Strike out any steps that do not apply -->

_**PR is ready for code review and approval when each box is checked.**_

_All steps are required, when applicable. ~Strikeout~ formatting indicates a step is not applicable to this change set._

- [x] Ticket referenced in PR title (ex. _SPT-XXX: Short summary of change_)