### PR TITLE
Update code and requirements to work on Python 3.6-3.12

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Run Tests
       run: py.test -v --cov=swimlane --cov-report=xml
     - name: Run Codacy Coverage
+      if: ${{ (github.event_name != 'pull_request') && (github.repository == 'swimlane/swimlane-python') }}
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
       run: python-codacy-coverage -r coverage.xml

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +33,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run Tests
-      run: py.test -v --cov=swimlane --cov-report=xml
+      run: python -m pytest -v --cov=swimlane --cov-report=xml
     - name: Run Codacy Coverage
       if: ${{ (github.repository == 'swimlane/swimlane-python') }}
       env:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   build:
     name: Build and test driver
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        runs-on: ["ubuntu-20.04", "ubuntu-22.04"]
         
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,11 +8,13 @@ on:
 jobs:
   build:
     name: Build and test driver
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        runs-on: ["ubuntu-20.04", "ubuntu-22.04"]
+        
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build and test driver
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   build:
     name: Build and test driver
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -11,14 +11,15 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
+        fail-fast: false
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build and test driver
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -10,8 +10,8 @@ jobs:
     name: Build and test driver
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run Tests
       run: py.test -v --cov=swimlane --cov-report=xml
     - name: Run Codacy Coverage
-      if: ${{ (github.event_name != 'pull_request') && (github.repository == 'swimlane/swimlane-python') }}
+      if: ${{ (github.repository == 'swimlane/swimlane-python') }}
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
       run: python-codacy-coverage -r coverage.xml

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     name: Build and test driver
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -2,9 +2,8 @@ name: "BuildAndTest"
 
 on:
   push:
-    branches: [master]
+
   pull_request:
-    branches: [master]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ functional_tests/pydriver-report.html
 # virtual environment
 venv3/
 venv/
+.direnv/
+.envrc

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,8 @@ Install the required PIP packages with the command
     pip install -r requirements.txt
 
 
-## Executing
+Executing
+---------
 
 The test suite allows for overriding the target server and user parameters via the following arguments:
 

--- a/README.rst
+++ b/README.rst
@@ -91,8 +91,6 @@ To run all the tests against 10.20.30.40
 
     No preset data is needed beyond the base user.
 
-    These tests are Python 2 and 3 compatible.
-
 Issues
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -61,22 +61,29 @@ Install the required PIP packages with the command
 
 
 Executing
----------
+^^^^^^^^^
 
-The test suite allows for overriding the target server and user parameters via the following arguments:
+The test suite allows for overriding the target server and user parameters via the following arguments
 
---url default="https://localhost"
---user default="admin"
---pass This is the password for the user defined above.
---skipverify This is for allowing the version of PyDriver to not match the version of Swimlane.
+::
 
-To run a specific test and skip the version verification:
+    pytest
+    --url default="https://localhost"
+    --user default="admin"
+    --pass This is the password for the user defined above.
+    --skipverify This is for allowing the version of PyDriver to not match the version of Swimlane.
 
-pytest driver_tests/test_app_adaptor.py --skipverify
+To run a specific test and skip the version verification
 
-To run all the tests against 10.20.30.40:
+::
 
-pytest --url "https://10.20.30.40"
+    pytest driver_tests/test_app_adaptor.py --skipverify
+
+To run all the tests against 10.20.30.40
+
+::
+
+    pytest --url "https://10.20.30.40"
 
 
 .. NOTE::

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cachetools==4.2.4
 certifi>=2017
-pendulum==2.1.2
+pendulum==2.1.2; python_version < '3.9'
+pendulum==3.0.0; python_version >= '3.9'
 pyjwt>=2.4.0
 pyuri>=0.3,<0.4
 requests[security]>=2,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cachetools>=2.0,<2.1
+cachetools==4.2.4
 certifi>=2017
 pendulum==2.1.2
 pyjwt>=2.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,5 @@ test=pytest
 universal=1
 
 [tool:pytest]
-python_paths = .
+pythonpath = .
 testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,12 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.8"
+        "Programming Language :: Python :: 3.9"
+        "Programming Language :: Python :: 3.10"
+        "Programming Language :: Python :: 3.11"
+        "Programming Language :: Python :: 3.12"
     ]
 )

--- a/swimlane/core/cursor.py
+++ b/swimlane/core/cursor.py
@@ -60,7 +60,10 @@ class PaginatedCursor(Cursor):
         """Lazily retrieve and paginate report results and build Record instances from returned data"""
         if self._elements:
             for element in self._elements:
-                yield element
+                try:
+                    yield element
+                except StopIteration:
+                    return
         else:
             # Determine pagination range based on parameters
             if self.page_start and self.page_end:

--- a/swimlane/core/cursor.py
+++ b/swimlane/core/cursor.py
@@ -10,11 +10,9 @@ class Cursor(object):
         return len(list(self._evaluate()))
 
     def __iter__(self):
-        try:
-            for element in self._evaluate():
-                yield element
-        except StopIteration:
-            return
+        for element in self._evaluate():
+            yield element
+        return
 
     def __getitem__(self, item):
         return self._evaluate()[item]
@@ -64,6 +62,7 @@ class PaginatedCursor(Cursor):
         if self._elements:
             for element in self._elements:
                 yield element
+            return
         else:
             # Determine pagination range based on parameters
             if self.page_start and self.page_end:

--- a/swimlane/core/cursor.py
+++ b/swimlane/core/cursor.py
@@ -12,7 +12,6 @@ class Cursor(object):
     def __iter__(self):
         for element in self._evaluate():
             yield element
-        return
 
     def __getitem__(self, item):
         return self._evaluate()[item]
@@ -62,7 +61,6 @@ class PaginatedCursor(Cursor):
         if self._elements:
             for element in self._elements:
                 yield element
-            return
         else:
             # Determine pagination range based on parameters
             if self.page_start and self.page_end:

--- a/swimlane/core/cursor.py
+++ b/swimlane/core/cursor.py
@@ -11,7 +11,10 @@ class Cursor(object):
 
     def __iter__(self):
         for element in self._evaluate():
-            yield element
+            try:
+                yield element
+            except StopIteration:
+                return
 
     def __getitem__(self, item):
         return self._evaluate()[item]

--- a/swimlane/core/cursor.py
+++ b/swimlane/core/cursor.py
@@ -10,11 +10,11 @@ class Cursor(object):
         return len(list(self._evaluate()))
 
     def __iter__(self):
-        for element in self._evaluate():
-            try:
+        try:
+            for element in self._evaluate():
                 yield element
-            except StopIteration:
-                return
+        except StopIteration:
+            return
 
     def __getitem__(self, item):
         return self._evaluate()[item]
@@ -63,10 +63,7 @@ class PaginatedCursor(Cursor):
         """Lazily retrieve and paginate report results and build Record instances from returned data"""
         if self._elements:
             for element in self._elements:
-                try:
-                    yield element
-                except StopIteration:
-                    return
+                yield element
         else:
             # Determine pagination range based on parameters
             if self.page_start and self.page_end:

--- a/swimlane/core/resources/usergroup.py
+++ b/swimlane/core/resources/usergroup.py
@@ -156,8 +156,10 @@ class GroupUsersCursor(SwimlaneResolver, Cursor):
         if self._elements:
             for element in self._elements:
                 yield element
+            return
         else:
             for user_id in self.__user_ids:
                 element = self._swimlane.users.get(id=user_id)
                 self._elements.append(element)
                 yield element
+            return

--- a/swimlane/core/resources/usergroup.py
+++ b/swimlane/core/resources/usergroup.py
@@ -156,10 +156,11 @@ class GroupUsersCursor(SwimlaneResolver, Cursor):
         if self._elements:
             for element in self._elements:
                 yield element
-            return
         else:
             for user_id in self.__user_ids:
-                element = self._swimlane.users.get(id=user_id)
-                self._elements.append(element)
-                yield element
-            return
+                try:
+                    element = self._swimlane.users.get(id=user_id)
+                    self._elements.append(element)
+                    yield element
+                except StopIteration:
+                    return

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 codacy-coverage==1.3.11
 coverage==6.2
 pytest==7.0.1
-pytest-cov==2.12.1
+pytest-cov==4.0.0
 tox==3.28.0
 pytz==2024.1
 pathlib==1.0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 codacy-coverage==1.3.11
 coverage==6.2
-pytest==3.10.1
+pytest==7.0.1
 pytest-cov==2.8.1
 pytest-pythonpath==0.7.4
 tox==3.28.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 codacy-coverage==1.3.11
 coverage==6.2
 pytest==7.0.1
-pytest-cov==2.8.1
+pytest-cov==2.12.1
 tox==3.28.0
 pytz==2024.1
 pathlib==1.0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 codacy-coverage==1.3.11
 coverage==6.2
-mock==5.1.0
 pytest==3.10.1
 pytest-cov==2.8.1
 pytest-pythonpath==0.7.4

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,9 @@
-coverage
-mock
+codacy-coverage==1.3.11
+coverage==6.2
+mock==5.1.0
 pytest==3.10.1
 pytest-cov==2.8.1
-pytest-pythonpath
-tox
-pytz
-pathlib
+pytest-pythonpath==0.7.4
+tox==3.28.0
+pytz==2024.1
+pathlib==1.0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,6 @@ codacy-coverage==1.3.11
 coverage==6.2
 pytest==7.0.1
 pytest-cov==2.8.1
-pytest-pythonpath==0.7.4
 tox==3.28.0
 pytz==2024.1
 pathlib==1.0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 codacy-coverage==1.3.11
-coverage==6.2
+coverage==6.2; python_version=='3.6'
+coverage==7.2.7; python_version>='3.7'
 pytest==7.0.1
 pytest-cov==4.0.0
 tox==3.28.0

--- a/tests/adapters/test_app_adapter.py
+++ b/tests/adapters/test_app_adapter.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock as mock
 import pytest
 
 

--- a/tests/adapters/test_app_revision_adapter.py
+++ b/tests/adapters/test_app_revision_adapter.py
@@ -1,6 +1,6 @@
 import math
 
-import mock
+import unittest.mock as mock
 
 from swimlane.core.resources.app_revision import AppRevision
 

--- a/tests/adapters/test_helper_adapter.py
+++ b/tests/adapters/test_helper_adapter.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock as mock
 
 app_id = '123'
 record_id = '456'

--- a/tests/adapters/test_record_adapter.py
+++ b/tests/adapters/test_record_adapter.py
@@ -1,6 +1,6 @@
 import numbers
 
-import mock
+import unittest.mock as mock
 import pytest
 import six
 

--- a/tests/adapters/test_record_revision_adapter.py
+++ b/tests/adapters/test_record_revision_adapter.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock as mock
 
 from swimlane.core.resources.record_revision import RecordRevision
 

--- a/tests/adapters/test_report_adapter.py
+++ b/tests/adapters/test_report_adapter.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock as mock
 
 from swimlane.core.resources.report import Report
 

--- a/tests/adapters/test_task_adapter.py
+++ b/tests/adapters/test_task_adapter.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-import mock
+import unittest.mock as mock
 from requests.models import Response
 from swimlane.core.adapters import TaskAdapter
 from swimlane.core.resources.task import Task

--- a/tests/adapters/test_usergroup_adapters.py
+++ b/tests/adapters/test_usergroup_adapters.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock as mock
 import pytest
 
 from swimlane.core.resources.usergroup import Group, User

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import random
 import json
 from pathlib import Path
 from shutil import copy as cp
-import mock
+import unittest.mock as mock
 import pytest
 from swimlane.core.client import SwimlaneJwtAuth, Swimlane
 from swimlane.core.resources.app import App

--- a/tests/fields/test_attachment.py
+++ b/tests/fields/test_attachment.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from io import BytesIO
+import unittest.mock as mock
 
-import mock
 import pytest
 from swimlane.core.fields.attachment import AttachmentCursor
 from swimlane.core.resources.attachment import Attachment

--- a/tests/fields/test_comment.py
+++ b/tests/fields/test_comment.py
@@ -1,6 +1,5 @@
 from datetime import datetime
-
-import mock
+import unittest.mock as mock
 
 from swimlane.core.fields.comment import CommentCursor
 from swimlane.core.resources.comment import Comment

--- a/tests/fields/test_history.py
+++ b/tests/fields/test_history.py
@@ -1,4 +1,5 @@
-import mock
+import unittest.mock as mock
+
 import pytest
 import pendulum
 

--- a/tests/fields/test_reference.py
+++ b/tests/fields/test_reference.py
@@ -1,4 +1,5 @@
-import mock
+import unittest.mock as mock
+
 import pytest
 
 from swimlane.core.fields.reference import ReferenceCursor

--- a/tests/resources/test_record.py
+++ b/tests/resources/test_record.py
@@ -1,6 +1,6 @@
 import json
 import pendulum
-import mock
+import unittest.mock as mock
 import pytest
 from requests import Response
 from swimlane.core.fields.reference import ReferenceCursor

--- a/tests/resources/test_record_revision.py
+++ b/tests/resources/test_record_revision.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock as mock
 import pendulum
 import pytest
 

--- a/tests/resources/test_report.py
+++ b/tests/resources/test_report.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock as mock
 import pytest
 
 from swimlane.core.resources.report import report_factory

--- a/tests/resources/test_usergroups.py
+++ b/tests/resources/test_usergroups.py
@@ -1,5 +1,5 @@
 import pytest
-from unitest.mock import patch
+from unittest.mock import patch
 import unittest.mock as mock
 import copy
 

--- a/tests/resources/test_usergroups.py
+++ b/tests/resources/test_usergroups.py
@@ -1,6 +1,6 @@
 import pytest
-from mock import patch
-import mock
+from unitest.mock import patch
+import unittest.mock as mock
 import copy
 
 from swimlane.core.cache import ResourcesCache

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,7 +2,7 @@
 
 import copy
 
-import mock
+import unittest.mock as mock
 import pytest
 
 from swimlane.core.cache import ResourcesCache, check_cache

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,5 @@
 """Tests for custom Swimlane errors"""
-import mock
+import unittest.mock as mock
 import pytest
 from requests import HTTPError
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import os
 import string
 import sys
 
-import mock
+import unittest.mock as mock
 import pytest
 from pkg_resources import DistributionNotFound
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py37,py38,py39,py310,py311,py312
 
 [testenv]
 passenv = LANG


### PR DESCRIPTION
* Run test suite on all branches and pull requests
* Run test suite on Python versions 3.6 - 3.12 without fail-fast.
* Update github actions for checkout and python-setup
* Add condition to only run Codacy while in main repo
* Update README.rst to remove Markdown fragments
* Update requirements.txt and test-requirements.txt to make this all work with minimal changes
* Use new `pythonpath` variable rather than `python_paths` for pytest
* Update Pypi settings to indicate supported Python versions
* Rewrite code to be PEP479 compliant for Python>=3.7
* Remove external `mock` dependency, it's in standard library