### PR TITLE
Replace dash-separated key in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [aliases]
 test=pytest


### PR DESCRIPTION
Setuptools deprecated dash-seperated keys in [v54.1.10 (2021)](https://setuptools.pypa.io/en/latest/history.html#id855) and they're advising [projects update before 2026](https://setuptools.pypa.io/en/latest/history.html#v78-0-2).