### PR TITLE
fix: Replace pyuri with stdlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ importlib-metadata>=4.0; python_version < '3.8'
 pendulum==2.1.2; python_version<='3.7'
 pendulum==3.2.0; python_version>='3.8'
 pyjwt>=2.4.0
-pyuri>=0.3,<0.4
 requests[security]>=2,<3; python_version<='3.7'
 requests==2.33.1; python_version>='3.8'
 six>=1.12.0

--- a/swimlane/core/client.py
+++ b/swimlane/core/client.py
@@ -6,12 +6,11 @@ import jwt
 import pendulum
 import requests
 import time
-from pyuri import URI
 from requests.compat import json
 from requests.packages import urllib3
 from requests.structures import CaseInsensitiveDict
 from requests.exceptions import ConnectionError
-from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin, urlparse, urlunparse
 
 from swimlane.core.adapters import GroupAdapter, UserAdapter, AppAdapter, HelperAdapter
 from swimlane.core.cache import ResourcesCache
@@ -53,7 +52,7 @@ class Swimlane(object):
         retry_interval (int): Time interval (in seconds) between two retry attempts
 
     Attributes:
-        host (pyuri.URI): Full RFC-1738 URL pointing to Swimlane host
+        host (urllib.parse.ParseResult): Full RFC-1738 URL pointing to Swimlane host
         apps (AppAdapter): :class:`~swimlane.core.adapters.app.AppAdapter` configured for current Swimlane instance
         users (UserAdapter): :class:`~swimlane.core.adapters.usergroup.UserAdapter` configured for current
             Swimlane instance
@@ -110,9 +109,10 @@ class Swimlane(object):
     ):
         self.__verify_auth_params(username, password, access_token)
 
-        self.host = URI(host)
-        self.host.scheme = (self.host.scheme or 'https').lower()
-        self.host.path = None
+        self.host = urlparse(host)
+        self.host = self.host._replace(
+            path='',
+            scheme=(self.host.scheme or 'https').lower())
 
         self.resources_cache = ResourcesCache(resource_cache_size)
 
@@ -194,7 +194,7 @@ class Swimlane(object):
         return '<{cls}: {user} @ {host} v{version}>'.format(
             cls=self.__class__.__name__,
             user=self.user,
-            host=self.host,
+            host=urlunparse(self.host),
             version=self.version
         )
 
@@ -258,7 +258,7 @@ class Swimlane(object):
             raise ValueError('retry_interval should be a positive integer')
         
         while not req_max_retries<0:
-            response = self._session.request(method, urljoin(str(self.host) + self._api_root, api_endpoint), **kwargs)
+            response = self._session.request(method, urljoin(urlunparse(self.host) + self._api_root, api_endpoint), **kwargs)
 
             # Roll 400 errors up into SwimlaneHTTP400Errors with specific Swimlane error code support
             try:


### PR DESCRIPTION
Replace pyuri with stdlib urllib functionality.

pyuri has not received an update in almost 10 years. It depends on the `pkg_resources` API, which was deprecated in setuptools 82.0.0. This prevents setuptools from being upgraded past that point in projects that have both setuptools and swimlane as runtime dependencies.

[GHSA-h35f-9h28-mq5c](https://github.com/advisories/GHSA-h35f-9h28-mq5c) was fixed in setuptools 83.0.0.

So, this change allows users of both swimlane and setuptools to upgrade setuptools to remediate GHSA-h35f-9h28-mq5c.